### PR TITLE
Get arguments from the specific experiment

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+extension-pkg-whitelist=pydantic

--- a/main.py
+++ b/main.py
@@ -50,6 +50,11 @@ async def list_directory(directory: str = "") -> List[str]:
     return remote.list_directory(os.path.join(configs["master_path"], directory))
 
 
+@app.get("/args/")
+async def get_arguments(file: str):
+    pass
+
+
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import pydantic
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List
 
@@ -50,8 +51,13 @@ async def list_directory(directory: str = "") -> List[str]:
     return remote.list_directory(os.path.join(configs["master_path"], directory))
 
 
-@app.get("/experiment/info/")
-async def get_experiment_info(file: str) -> Dict[str, Dict[str, Any]]:
+class ExperimentInfo(pydantic.BaseModel):
+    name: str
+    arginfo: Dict[str, Any]
+
+
+@app.get("/experiment/info/", response_model=Dict[str, ExperimentInfo])
+async def get_experiment_info(file: str) -> Any:
     """Get information of the given experiment file and returns it.
     
     Args:
@@ -59,9 +65,12 @@ async def get_experiment_info(file: str) -> Dict[str, Dict[str, Any]]:
 
     Returns:
         A dictionary containing only one element of which key is the class name.
-        The value is a dictionary with four keys (show only two important things):
-          name: The experiment name.
+        The value is a dictionary with two keys:
+          name: The experiment name which is set as the docstring in the experiment file.
           arginfo: The dictionary containing arguments of the experiment.
+            Each key is an argument name and its value contains the argument type,
+            the default value, and the additional information for the argument.
+
     """
     remote = get_client("master_experiment_db")
     return remote.examine(file)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 import json
 import os
 from contextlib import asynccontextmanager
-from typing import List
+from typing import Any, Dict, List
 
 from fastapi import FastAPI
 from sipyco import pc_rpc as rpc
@@ -51,7 +51,18 @@ async def list_directory(directory: str = "") -> List[str]:
 
 
 @app.get("/args/")
-async def get_arguments(file: str):
+async def get_arguments(file: str) -> Dict[str, Dict[str, Any]]:
+    """Get arguments of the given experiment file and returns it.
+    
+    Args:
+        file: The path of the experiment file.
+
+    Returns:
+        A dictionary containing only one element of which key is the class name.
+        The value is a dictionary with two keys:
+          name: The experiment name.
+          arginfo: The dictionary containing arguments of the experiment.
+    """
     remote = get_client("master_experiment_db")
     return remote.examine(file)
 

--- a/main.py
+++ b/main.py
@@ -2,10 +2,10 @@
 
 import json
 import os
-import pydantic
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List
 
+import pydantic
 from fastapi import FastAPI
 from sipyco import pc_rpc as rpc
 

--- a/main.py
+++ b/main.py
@@ -52,6 +52,16 @@ async def list_directory(directory: str = "") -> List[str]:
 
 
 class ExperimentInfo(pydantic.BaseModel):
+    """Experiment information.
+    
+    This is the return type of get_experiment_info().
+
+    Fields:
+        name: The experiment name which is set as the docstring in the experiment file.
+        arginfo: The dictionary containing arguments of the experiment.
+          Each key is an argument name and its value contains the argument type,
+          the default value, and the additional information for the argument.
+    """
     name: str
     arginfo: Dict[str, Any]
 
@@ -64,13 +74,8 @@ async def get_experiment_info(file: str) -> Any:
         file: The path of the experiment file.
 
     Returns:
-        A dictionary containing only one element of which key is the class name.
-        The value is a dictionary with two keys:
-          name: The experiment name which is set as the docstring in the experiment file.
-          arginfo: The dictionary containing arguments of the experiment.
-            Each key is an argument name and its value contains the argument type,
-            the default value, and the additional information for the argument.
-
+        A dictionary containing only one element of which key is the experiment class name.
+        The value is an ExperimentInfo object.
     """
     remote = get_client("master_experiment_db")
     return remote.examine(file)

--- a/main.py
+++ b/main.py
@@ -52,7 +52,8 @@ async def list_directory(directory: str = "") -> List[str]:
 
 @app.get("/args/")
 async def get_arguments(file: str):
-    pass
+    remote = get_client("master_experiment_db")
+    return remote.examine(file)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -50,9 +50,9 @@ async def list_directory(directory: str = "") -> List[str]:
     return remote.list_directory(os.path.join(configs["master_path"], directory))
 
 
-@app.get("/args/")
-async def get_arguments(file: str) -> Dict[str, Dict[str, Any]]:
-    """Get arguments of the given experiment file and returns it.
+@app.get("/experiment/info/")
+async def get_experiment_info(file: str) -> Dict[str, Dict[str, Any]]:
+    """Get information of the given experiment file and returns it.
     
     Args:
         file: The path of the experiment file.

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ async def get_arguments(file: str) -> Dict[str, Dict[str, Any]]:
 
     Returns:
         A dictionary containing only one element of which key is the class name.
-        The value is a dictionary with two keys:
+        The value is a dictionary with four keys (show only two important things):
           name: The experiment name.
           arginfo: The dictionary containing arguments of the experiment.
     """


### PR DESCRIPTION
This will close #5.

I implemented a proxy to get arguments from the specific experiment.

You can get arguments as follows.
```shell
$ curl -X GET 127.0.0.1:8000/args/?file=exp.py
```

The example result is as follows.

<img width="100%" src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/6b2cb5a0-ebc4-4467-a4d1-273bdb859b9e">

```json
{
  "PulseSimulation": {
    "name": "Pulse simulation",
    "arginfo": {
      "user": [{"ty": "StringValue", "default": "QuIQCL"}, null, null],
      "time": [{"ty": "NumberValue", "default": 1.0, "unit": "", "scale": 1.0, "step": 0.1, "min": null, "max": null, "ndecimals": 2, "type": "auto"}, null, null],
      "save": [{"ty": "BooleanValue", "default": false}, null, null],
      "color": [{"ty": "EnumerationValue", "default": "r", "choices": ["r", "g", "b"]}, null, null]
    },
    "argument_ui": null,
    "scheduler_defaults": {}
  }
}
```