### PR TITLE
Submit the specific experiment

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,3 +1,4 @@
 {
-    "master_path": "/home/rabi/artiq/"
+    "master_path": "/home/rabi/artiq/",
+    "repository_path": "repository"
 }

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import logging
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List
 
@@ -80,9 +81,18 @@ async def get_experiment_info(file: str) -> Any:
     remote = get_client("master_experiment_db")
     return remote.examine(file)
 
+
 @app.get("/experiment/submit/")
-async def submit_experiment(file: str) -> Any:
-    pass
+async def submit_experiment(file: str, args: str = "{}") -> int:
+    """Submit the given experiment file."""
+    expid = {
+        "log_level": logging.WARNING,
+        "class_name": None,
+        "arguments": json.loads(args),
+        "file": file
+    }
+    remote = get_client("master_schedule")
+    return remote.submit("main", expid, 0, None, False)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """Proxy server to communicate a client to ARTIQ."""
 
 import json
-import os
+import posixpath
 import logging
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List
@@ -50,7 +50,7 @@ async def list_directory(directory: str = "") -> List[str]:
         directory: The path of the directory to search for.
     """
     remote = get_client("master_experiment_db")
-    return remote.list_directory(os.path.join(configs["master_path"], directory))
+    return remote.list_directory(posixpath.join(configs["master_path"], directory))
 
 
 class ExperimentInfo(pydantic.BaseModel):
@@ -99,7 +99,7 @@ async def submit_experiment(file: str, args: str = "{}") -> int:
         "log_level": logging.WARNING,
         "class_name": None,
         "arguments": json.loads(args),
-        "file": os.path.join(configs["repository_path"], file)
+        "file": posixpath.join(configs["repository_path"], file)
     }
     remote = get_client("master_schedule")
     return remote.submit("main", expid, 0, None, False)

--- a/main.py
+++ b/main.py
@@ -80,6 +80,10 @@ async def get_experiment_info(file: str) -> Any:
     remote = get_client("master_experiment_db")
     return remote.examine(file)
 
+@app.get("/experiment/submit/")
+async def submit_experiment(file: str) -> Any:
+    pass
+
 
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def load_config_file():
 
       {
         "master_path": {master_path}
+        "repository_path": {repository_path}
       }
     """
     with open("config.json", encoding="utf-8") as config_file:
@@ -89,7 +90,7 @@ async def submit_experiment(file: str, args: str = "{}") -> int:
         "log_level": logging.WARNING,
         "class_name": None,
         "arguments": json.loads(args),
-        "file": file
+        "file": os.path.join(configs["repository_path"], file)
     }
     remote = get_client("master_schedule")
     return remote.submit("main", expid, 0, None, False)

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ app = FastAPI(lifespan=lifespan)
 
 @app.get("/ls/")
 async def list_directory(directory: str = "") -> List[str]:
-    """Get the list of elements in the given path and returns it.
+    """Gets the list of elements in the given path and returns it.
 
     The "master_path" in the configuration file is used for the prefix of the path.
 
@@ -70,7 +70,7 @@ class ExperimentInfo(pydantic.BaseModel):
 
 @app.get("/experiment/info/", response_model=Dict[str, ExperimentInfo])
 async def get_experiment_info(file: str) -> Any:
-    """Get information of the given experiment file and returns it.
+    """Gets information of the given experiment file and returns it.
     
     Args:
         file: The path of the experiment file.
@@ -85,11 +85,11 @@ async def get_experiment_info(file: str) -> Any:
 
 @app.get("/experiment/submit/")
 async def submit_experiment(file: str, args: str = "{}") -> int:
-    """Submit the given experiment file.
+    """Submits the given experiment file.
     
     Args:
         file: The path of the experiment file.
-        args: The arguments to submit which must be JSONifiable to a dictionary.
+        args: The arguments to submit which must be a JSON string of a dictionary.
           Each key is an argument name and its value is the value of the argument.
     
     Returns:

--- a/main.py
+++ b/main.py
@@ -85,7 +85,16 @@ async def get_experiment_info(file: str) -> Any:
 
 @app.get("/experiment/submit/")
 async def submit_experiment(file: str, args: str = "{}") -> int:
-    """Submit the given experiment file."""
+    """Submit the given experiment file.
+    
+    Args:
+        file: The path of the experiment file.
+        args: The arguments to submit which must be JSONifiable to a dictionary.
+          Each key is an argument name and its value is the value of the argument.
+    
+    Returns:
+        The run identifier, an integer which is incremented at each experiment submission.
+    """
     expid = {
         "log_level": logging.WARNING,
         "class_name": None,


### PR DESCRIPTION
This will close #6.

I implmented a proxy to submit an experiment.

You can submit it as follows:
```shell
$ http://127.0.0.1:8000/experiment/submit/?file=pulse.py  # no arguments
$ http://127.0.0.1:8000/experiment/submit/?file=pulse.py&args={"time":3,"user":"jaehun"}
```

I thought a lot about how to pass the arguments. The solutions are as follows:
1. Use dynamic parameters
Later, there may be additional parameters such as a due date, a priority.
Thus, it makes us difficult to distinguish the experiment argumetns and these other parameters. 
2. Use a JSONifiable string (_Selected_)
Pass the arguments as a JSONifiable string such as `'{"key1": "value1", "key2": "value2"}'`.
I think it is the most convenient since we can encode and decode with just one function i.e. `json.dumps()` and `json.loads()`.

And I didn't check if a decode exception occurs because it can be handled internally.
If so, the server returns a string "Internal Server Error".

Also regardless of whether the submission is successful or not, the return is always the rid number.
The success or failure can be checked only in the `artiq_master` terminal.