### PR TITLE
Handle the scheduler options in submission

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,6 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         python -m pip install --upgrade pip
         pip install pylint
     - name: Add dependencies about external libraries

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,6 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         python -m pip install --upgrade pip
         pip install coverage
     - name: Add dependencies about external libraries

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         pip install fastapi
         pip install httpx
+        pip install numpy
         pip install git+https://github.com/m-labs/sipyco.git
     - name: Run the unit tests and check coverage
       run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,29 @@
+name: Unit test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install coverage
+    - name: Add dependencies about external libraries
+      run: |
+        pip install fastapi
+        pip install requests
+        pip install git+https://github.com/m-labs/sipyco.git
+    - name: Run the unit tests and check coverage
+      run: |
+        xvfb-run `which coverage` run -m unittest test.py
+        xvfb-run `which coverage` report main.py

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Add dependencies about external libraries
       run: |
         pip install fastapi
-        pip install requests
+        pip install httpx
         pip install git+https://github.com/m-labs/sipyco.git
     - name: Run the unit tests and check coverage
       run: |

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "master_path": "/home/rabi/artiq/",
-    "repository_path": "repository"
+    "repository_path": "repository/"
 }

--- a/main.py
+++ b/main.py
@@ -103,9 +103,9 @@ async def submit_experiment(
         args: The arguments to submit which must be a JSON string of a dictionary.
           Each key is an argument name and its value is the value of the argument.
         pipeline: The pipeline to run the experiment in.
-        priority: The priority that higher value means sooner scheduling.
-        timed: The due date for the experiment of which format is "YYYY-MM-DDTHH:MM:SS".
-          If there is no due date, it is set to None.
+        priority: Higher value means sooner scheduling.
+        timed: The due date for the experiment in ISO format.
+          None for no due date.
     
     Returns:
         The run identifier, an integer which is incremented at each experiment submission.

--- a/test.py
+++ b/test.py
@@ -21,12 +21,13 @@ class RoutingTest(unittest.TestCase):
     @mock.patch.dict("main.configs", {"master_path": "master_path/"})
     def test_list_directory(self):
         test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
-        self.mocked_get_client.return_value.list_directory.return_value = test_list
+        mocked_client = self.mocked_get_client.return_value
+        mocked_client.list_directory.return_value = test_list
         with TestClient(main.app) as client:
             for query, path in [("", ""), ("?directory=dir1/", "dir1/")]:
                 response = client.get("/ls/" + query)
                 self.mocked_load_config_file.assert_called()
-                self.mocked_get_client.return_value.list_directory.assert_called_with(
+                mocked_client.list_directory.assert_called_with(
                     "master_path/" + path
                 )
                 self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 import main
 
 
-class Test(unittest.TestCase):
+class RoutingTest(unittest.TestCase):
     """Unit tests for routing and each operation."""
 
     def setUp(self):

--- a/test.py
+++ b/test.py
@@ -11,9 +11,26 @@ class Test(unittest.TestCase):
     """Unit tests for routing and each operation."""
 
     def setUp(self):
-        patcher = mock.patch("main.get_client")
-        self.mocked_get_client = patcher.start()
-        self.addCleanup(patcher.stop)
+        patcher_load_config_file = mock.patch("main.load_config_file")
+        patcher_get_client = mock.patch("main.get_client")
+        self.mocked_load_config_file = patcher_load_config_file.start()
+        self.mocked_get_client = patcher_get_client.start()
+        self.addCleanup(patcher_load_config_file.stop)
+        self.addCleanup(patcher_get_client.stop)
+
+    @mock.patch.dict("main.configs", {"master_path": "master_path/"})
+    def test_list_directory_return(self):
+        """Tests if the return value is correct."""
+        test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
+        self.mocked_get_client.return_value.list_directory.return_value = test_list
+        with TestClient(main.app) as client:
+            response = client.get("/ls/")
+        self.mocked_load_config_file.assert_called_once()
+        self.mocked_get_client.return_value.list_directory.assert_called_once_with(
+            "master_path/"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), test_list)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -34,6 +34,26 @@ class RoutingTest(unittest.TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_list)
 
+    def test_get_experiment_info(self):
+        test_info = {
+            "ExperimentClass": main.ExperimentInfo(
+                name="experiment_name",
+                arginfo={
+                    "arg1": [{"ty": "StringValue", "default": "DEFAULT"}, None, None],
+                    "arg2": [{"ty": "BooleanValue", "default": True}, None, None]
+                }
+            )
+        }
+        mocked_client = self.mocked_get_client.return_value
+        mocked_client.examine.return_value = test_info
+        with TestClient(main.app) as client:
+            self.mocked_load_config_file.assert_called_once()
+            response = client.get("/experiment/info/?file=experiment.py")
+            mocked_client.examine.assert_called_with("experiment.py")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), test_info)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+"""Unit tests for main module."""
+
+import unittest
+from unittest import mock
+from fastapi.testclient import TestClient
+
+import main
+
+
+class Test(unittest.TestCase):
+    """Unit tests for routing and each operation."""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -19,18 +19,18 @@ class Test(unittest.TestCase):
         self.addCleanup(patcher_get_client.stop)
 
     @mock.patch.dict("main.configs", {"master_path": "master_path/"})
-    def test_list_directory_return(self):
-        """Tests if list_directory() returns correctly."""
+    def test_list_directory(self):
         test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
         self.mocked_get_client.return_value.list_directory.return_value = test_list
         with TestClient(main.app) as client:
-            response = client.get("/ls/")
-        self.mocked_load_config_file.assert_called_once()
-        self.mocked_get_client.return_value.list_directory.assert_called_once_with(
-            "master_path/"
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), test_list)
+            for query, path in [("", ""), ("?directory=dir1/", "dir1/")]:
+                response = client.get("/ls/" + query)
+                self.mocked_load_config_file.assert_called()
+                self.mocked_get_client.return_value.list_directory.assert_called_with(
+                    "master_path/" + path
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), test_list)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -5,6 +5,7 @@ import json
 import posixpath
 import unittest
 from unittest import mock
+
 from fastapi.testclient import TestClient
 
 import main

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
 
     @mock.patch.dict("main.configs", {"master_path": "master_path/"})
     def test_list_directory_return(self):
-        """Tests if the return value is correct."""
+        """Tests if list_directory() returns correctly."""
         test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
         self.mocked_get_client.return_value.list_directory.return_value = test_list
         with TestClient(main.app) as client:

--- a/test.py
+++ b/test.py
@@ -9,7 +9,6 @@ from fastapi.testclient import TestClient
 
 import main
 
-
 class RoutingTest(unittest.TestCase):
     """Unit tests for routing and each operation."""
 
@@ -76,6 +75,16 @@ class RoutingTest(unittest.TestCase):
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_rid)
+
+
+class FunctionTest(unittest.TestCase):
+    """Unit tests for other functions."""
+
+    @mock.patch("main.rpc.Client")
+    def test_get_client(self, mocked_client_cls):
+        for target_name in ["name1", "name2"]:
+            main.get_client(target_name)
+            mocked_client_cls.assert_called_with("::1", 3251, target_name)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -25,7 +25,7 @@ class RoutingTest(unittest.TestCase):
         mocked_client.list_directory.return_value = test_list
         with TestClient(main.app) as client:
             for query, path in [("", ""), ("?directory=dir1/", "dir1/")]:
-                response = client.get("/ls/" + query)
+                response = client.get(f"/ls/{query}")
                 self.mocked_load_config_file.assert_called()
                 mocked_client.list_directory.assert_called_with(
                     "master_path/" + path

--- a/test.py
+++ b/test.py
@@ -10,6 +10,11 @@ import main
 class Test(unittest.TestCase):
     """Unit tests for routing and each operation."""
 
+    def setUp(self):
+        patcher = mock.patch("main.get_client")
+        self.mocked_get_client = patcher.start()
+        self.addCleanup(patcher.stop)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -80,6 +80,16 @@ class RoutingTest(unittest.TestCase):
 class FunctionTest(unittest.TestCase):
     """Unit tests for other functions."""
 
+    @mock.patch("builtins.open")
+    @mock.patch("json.load",
+                return_value={"master_path": "master_path/", "repository_path": "repo_path/"})
+    def test_load_config_file(self, mocked_load, mocked_open):
+        main.load_config_file()
+        mocked_open.assert_called_once_with("config.json", encoding="utf-8")
+        mocked_load.assert_called_once()
+        self.assertEquals(main.configs,
+                          {"master_path": "master_path/", "repository_path": "repo_path/"})
+
     @mock.patch("main.rpc.Client")
     def test_get_client(self, mocked_client_cls):
         for target_name in ["name1", "name2"]:

--- a/test.py
+++ b/test.py
@@ -29,7 +29,7 @@ class RoutingTest(unittest.TestCase):
         with TestClient(main.app) as client:
             self.mocked_load_config_file.assert_called_once()
             for params in [{}, {"directory": "dir1/"}]:
-                response = client.get(f"/ls/", params=params)
+                response = client.get("/ls/", params=params)
                 mocked_client.list_directory.assert_called_with(
                     f"master_path/repo_path/{params.get('directory', '')}")
                 self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -18,17 +18,18 @@ class RoutingTest(unittest.TestCase):
         self.addCleanup(patcher_load_config_file.stop)
         self.addCleanup(patcher_get_client.stop)
 
-    @mock.patch.dict("main.configs", {"master_path": "master_path/"})
+    @mock.patch.dict("main.configs",
+                     {"master_path": "master_path/", "repository_path": "repo_path/"})
     def test_list_directory(self):
         test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
         mocked_client = self.mocked_get_client.return_value
         mocked_client.list_directory.return_value = test_list
         with TestClient(main.app) as client:
+            self.mocked_load_config_file.assert_called_once()
             for query, path in [("", ""), ("?directory=dir1/", "dir1/")]:
                 response = client.get(f"/ls/{query}")
-                self.mocked_load_config_file.assert_called()
                 mocked_client.list_directory.assert_called_with(
-                    "master_path/" + path
+                    "master_path/repo_path/" + path
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_list)

--- a/test.py
+++ b/test.py
@@ -32,6 +32,7 @@ class RoutingTest(unittest.TestCase):
             for params in ({}, {"directory": "dir1/"}):
                 directory = params.get('directory', '')
                 response = client.get("/ls/", params=params)
+                directory = params.get('directory', '')
                 self.mocked_client.list_directory.assert_called_with(
                     f"master_path/repo_path/{directory}")
                 self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ class RoutingTest(unittest.TestCase):
         mocked_client.list_directory.return_value = test_list
         with TestClient(main.app) as client:
             self.mocked_load_config_file.assert_called_once()
-            for params in [{}, {"directory": "dir1/"}]:
+            for params in ({}, {"directory": "dir1/"}):
                 directory = params.get('directory', '')
                 response = client.get("/ls/", params=params)
                 mocked_client.list_directory.assert_called_with(
@@ -62,9 +62,11 @@ class RoutingTest(unittest.TestCase):
         mocked_client.submit.return_value = test_rid
         with TestClient(main.app) as client:
             self.mocked_load_config_file.assert_called_once()
-            for params in [
+            test_params = (
                 {"file": "experiment1.py"},
-                {"file": "experiment2.py", "args": '{"k": "v"}'}]:
+                {"file": "experiment2.py", "args": '{"k": "v"}'}
+            )
+            for params in test_params:
                 expid = {
                     "log_level": logging.WARNING,
                     "class_name": None,
@@ -92,7 +94,7 @@ class FunctionTest(unittest.TestCase):
 
     @mock.patch("main.rpc.Client")
     def test_get_client(self, mocked_client_cls):
-        for target_name in ["name1", "name2"]:
+        for target_name in ("name1", "name2"):
             main.get_client(target_name)
             mocked_client_cls.assert_called_with("::1", 3251, target_name)
 

--- a/test.py
+++ b/test.py
@@ -28,9 +28,7 @@ class RoutingTest(unittest.TestCase):
             self.mocked_load_config_file.assert_called_once()
             for query, path in [("", ""), ("?directory=dir1/", "dir1/")]:
                 response = client.get(f"/ls/{query}")
-                mocked_client.list_directory.assert_called_with(
-                    "master_path/repo_path/" + path
-                )
+                mocked_client.list_directory.assert_called_with(f"master_path/repo_path/{path}")
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_list)
 

--- a/test.py
+++ b/test.py
@@ -34,7 +34,6 @@ class RoutingTest(unittest.TestCase):
             for params in ({}, {"directory": "dir1/"}):
                 directory = params.get('directory', '')
                 response = client.get("/ls/", params=params)
-                directory = params.get('directory', '')
                 self.mocked_client.list_directory.assert_called_with(
                     f"master_path/repo_path/{directory}")
                 self.assertEqual(response.status_code, 200)

--- a/test.py
+++ b/test.py
@@ -29,9 +29,10 @@ class RoutingTest(unittest.TestCase):
         with TestClient(main.app) as client:
             self.mocked_load_config_file.assert_called_once()
             for params in [{}, {"directory": "dir1/"}]:
+                directory = params.get('directory', '')
                 response = client.get("/ls/", params=params)
                 mocked_client.list_directory.assert_called_with(
-                    f"master_path/repo_path/{params.get('directory', '')}")
+                    f"master_path/repo_path/{directory}")
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_list)
 
@@ -64,15 +65,14 @@ class RoutingTest(unittest.TestCase):
             for params in [
                 {"file": "experiment1.py"},
                 {"file": "experiment2.py", "args": '{"k": "v"}'}]:
+                expid = {
+                    "log_level": logging.WARNING,
+                    "class_name": None,
+                    "arguments": json.loads(params.get("args", "{}")),
+                    "file": posixpath.join("repo_path", params["file"])
+                }
                 response = client.get("/experiment/submit/", params=params)
-                mocked_client.submit.assert_called_with(
-                    "main", {
-                        "log_level": logging.WARNING,
-                        "class_name": None,
-                        "arguments": json.loads(params.get("args", "{}")),
-                        "file": posixpath.join("repo_path", params["file"])
-                    }, 0, None, False
-                )
+                mocked_client.submit.assert_called_with("main", expid, 0, None, False)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), test_rid)
 

--- a/test.py
+++ b/test.py
@@ -88,7 +88,7 @@ class FunctionTest(unittest.TestCase):
         main.load_config_file()
         mocked_open.assert_called_once_with("config.json", encoding="utf-8")
         mocked_load.assert_called_once()
-        self.assertEquals(main.configs,
+        self.assertEqual(main.configs,
                           {"master_path": "master_path/", "repository_path": "repo_path/"})
 
     @mock.patch("main.rpc.Client")


### PR DESCRIPTION
This PR will close #16.

First of all, please check and merge the PR #12.

I made the submission function able to handle the scheduler options; `pipeline`, `priority`, and `timed`.
You can test the submission using the following url.
```shell
http://127.0.0.1:8000/experiment/submit/?file=simple_simulation.py&args={%22color%22:%20%22r%22}&pipeline=main2&priority=0&timed=2023-06-26T09:53:00
```
Also, due to the encoding problem, please request the query in your browser such as Chrome or Safari, not `curl` command.