### PR TITLE
Sort the returns of `list_directory()`

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ async def list_directory(directory: str = "") -> List[str]:
 
     Returns:
         A list with items in the given directory.
-        It lists directories before files, and is sorted alphabetically internally.
+        It lists directories before files, sorted in an alphabetical order.
     """
     remote = get_client("master_experiment_db")
     full_path = posixpath.join(configs["master_path"], configs["repository_path"], directory)

--- a/main.py
+++ b/main.py
@@ -51,11 +51,18 @@ async def list_directory(directory: str = "") -> List[str]:
 
     Args:
         directory: The path of the directory to search for.
+
+    Returns:
+        A list with items in the given directory.
+        It lists directories before files, and is sorted alphabetically internally.
     """
     remote = get_client("master_experiment_db")
-    return remote.list_directory(posixpath.join(
-        configs["master_path"], configs["repository_path"], directory
-    ))
+    full_path = posixpath.join(configs["master_path"], configs["repository_path"], directory)
+    item_list = remote.list_directory(full_path)
+    return sorted(
+        item_list,
+        key=lambda item: (not item.endswith("/"), item)
+    )
 
 
 class ExperimentInfo(pydantic.BaseModel):

--- a/server.sh
+++ b/server.sh
@@ -1,1 +1,1 @@
-python -m uvicorn main:app --reload --host=0.0.0.0 --port 8000
+python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This PR will close #13.

I sorted the returns of `list_directory()`.

1. List directories before files.
2. Sort alphabetically internally.

### Results
<img width="80%" src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/bcf2a2ee-d642-4867-906c-46a304ab8036">
