### PR TITLE
Support the visualization option in submission

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "master_path": "/home/rabi/artiq/",
-    "repository_path": "repository/"
+    "repository_path": "repository/",
+    "visualize_path": "visualize/"
 }

--- a/main.py
+++ b/main.py
@@ -114,7 +114,8 @@ async def submit_experiment(
     args: str = "{}",
     pipeline: str = "main",
     priority: int = 0,
-    timed: Optional[str] = None
+    timed: Optional[str] = None,
+    visualize: Optional[bool] = False
 ) -> int:
     """Submits the given experiment file.
     
@@ -126,10 +127,16 @@ async def submit_experiment(
         priority: Higher value means sooner scheduling.
         timed: The due date for the experiment in ISO format.
           None for no due date.
+        visualize: If True, the experiment file is modified for visualization.
+          The original file and vcd file are saved in the visualize path set in config.json.
     
     Returns:
         The run identifier, an integer which is incremented at each experiment submission.
     """
+    if visualize:
+        pass
+    else:
+        pass
     expid = {
         "log_level": logging.WARNING,
         "class_name": None,

--- a/main.py
+++ b/main.py
@@ -95,19 +95,6 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
-@app.get("/experiment/code/")
-async def get_experiment_code(file: str) -> str:
-    """Gets code of the given experiment file and returns it.
-    
-    Args:
-        file: The path of the experiment file.
-    """
-    full_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
-    with open(full_path, encoding="utf-8") as experiment_file:
-        code = experiment_file.read()
-    return code
-
-
 @app.get("/experiment/submit/")
 async def submit_experiment(
     file: str,

--- a/main.py
+++ b/main.py
@@ -121,7 +121,10 @@ async def submit_experiment(
         The run identifier, an integer which is incremented at each experiment submission.
     """
     if visualize:
-        pass
+        full_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
+        with open(full_path, encoding="utf-8") as experiment_file:
+            code = experiment_file.read()
+        # TODO(BECATRUE): The code will be modifed in #37.
     else:
         pass
     expid = {

--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@
 
 import json
 import logging
+import os
 import posixpath
+import shutil
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -121,8 +123,8 @@ async def submit_experiment(
         The run identifier, an integer which is incremented at each experiment submission.
     """
     if visualize:
-        full_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
-        with open(full_path, encoding="utf-8") as experiment_file:
+        experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
+        with open(experiment_path, encoding="utf-8") as experiment_file:
             code = experiment_file.read()
         # TODO(BECATRUE): The code will be modifed in #37.
     else:
@@ -135,7 +137,17 @@ async def submit_experiment(
     }
     due_date = None if timed is None else time.mktime(datetime.fromisoformat(timed).timetuple())
     remote = get_client("master_schedule")
-    return remote.submit(pipeline, expid, priority, due_date, False)
+    rid = remote.submit(pipeline, expid, priority, due_date, False)
+    if visualize:
+        visualize_dir_path = posixpath.join(
+            configs["master_path"],
+            configs["visualize_path"],
+            f"{rid}/"
+        )
+        os.makedirs(visualize_dir_path)
+        copied_experiment_path = posixpath.join(visualize_dir_path, "experiment.py")
+        shutil.copyfile(experiment_path, copied_experiment_path)
+    return rid
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ async def submit_experiment(
     priority: int = 0,
     timed: Optional[str] = None,
     visualize: Optional[bool] = False
-) -> int:
+) -> int:  # pylint: disable=too-many-arguments
     """Submits the given experiment file.
     
     Args:
@@ -125,7 +125,7 @@ async def submit_experiment(
     if visualize:
         experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
         with open(experiment_path, encoding="utf-8") as experiment_file:
-            code = experiment_file.read()
+            _code = experiment_file.read()
         # TODO(BECATRUE): The code will be modifed in #37.
     else:
         pass

--- a/main.py
+++ b/main.py
@@ -98,14 +98,14 @@ async def get_experiment_info(file: str) -> Any:
 
 
 @app.get("/experiment/submit/")
-async def submit_experiment(
+async def submit_experiment(  # pylint: disable=too-many-arguments
     file: str,
     args: str = "{}",
     pipeline: str = "main",
     priority: int = 0,
     timed: Optional[str] = None,
     visualize: Optional[bool] = False
-) -> int:  # pylint: disable=too-many-arguments
+) -> int:
     """Submits the given experiment file.
     
     Args:

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
     pipeline: str = "main",
     priority: int = 0,
     timed: Optional[str] = None,
-    visualize: Optional[bool] = False
+    visualize: bool = False
 ) -> int:
     """Submits the given experiment file.
     

--- a/main.py
+++ b/main.py
@@ -128,6 +128,7 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
             _code = experiment_file.read()
         # TODO(BECATRUE): The code will be modifed in #37.
     else:
+        # TODO(BECATRUE): The exact experiment path will be assigned in #37.
         pass
     expid = {
         "log_level": logging.WARNING,


### PR DESCRIPTION
This PR will close #36.

I implemented the followings:
- Remove fetching a specific experiment code (we will not use anymore.)
- Add the visualize option. (The default is not to visualize.)
- If the option is `True`, the original code is copied in `${master_path}/{visualize_path}/{rid}/experiment.py`.

### Result
I sent the query below.
```shell
http://127.0.0.1:8000/experiment/submit/?file=simple_simulation.py&visualize=True
```

Its RID was 277 and in my ARTIQ master path, the following structure was created.

<image width="50%" src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/e4ce9366-6e51-4596-a54c-361f07f552c4">