### PR TITLE
Make an experiment fetcher

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,6 +95,19 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
+@app.get("/experiment/queue/", response_model=Dict)
+async def get_experiment_queue() -> Dict:
+    """Gets the list of queued experiment returns it.
+
+    Returns:
+        A dictionary of queued experiments with rid as their keys.
+        It includes the running experiment with different "status" value.
+    """
+    remote = get_client("master_schedule")
+    current_experiment = remote.get_status()
+    return current_experiment
+
+
 @app.get("/experiment/code/")
 async def get_experiment_code(file: str) -> str:
     """Gets code of the given experiment file and returns it.

--- a/main.py
+++ b/main.py
@@ -95,8 +95,8 @@ async def get_experiment_info(file: str) -> Any:
     remote = get_client("master_experiment_db")
     return remote.examine(file)
 
-
-current_queue = previous_queue = dict()
+previous_queue = {}
+current_queue = {}
 @app.get("/experiment/queue/", response_model=Dict[int, Dict[str, Any]])
 async def get_experiment_queue() -> Dict[int, Dict[str, Any]]:
     """Gets the list of queued experiment and returns it.
@@ -107,12 +107,13 @@ async def get_experiment_queue() -> Dict[int, Dict[str, Any]]:
           "priority", "status", "flush", "pipeline", "expid", and etc.
         It includes the running experiment with different "status" value.
     """
-    global current_queue, previous_queue
     remote = get_client("master_schedule")
     while current_queue == previous_queue:
         await asyncio.sleep(0)
-        current_queue = remote.get_status()
-    previous_queue = current_queue
+        current_queue.clear()
+        current_queue.update(remote.get_status())
+    previous_queue.clear()
+    previous_queue.update(current_queue)
     return current_queue
 
 

--- a/main.py
+++ b/main.py
@@ -95,6 +95,7 @@ async def get_experiment_info(file: str) -> Any:
     remote = get_client("master_experiment_db")
     return remote.examine(file)
 
+
 previous_queue = {}
 current_queue = {}
 @app.get("/experiment/queue/", response_model=Dict[int, Dict[str, Any]])

--- a/main.py
+++ b/main.py
@@ -95,17 +95,18 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
-@app.get("/experiment/queue/", response_model=Dict)
-async def get_experiment_queue() -> Dict:
-    """Gets the list of queued experiment returns it.
+@app.get("/experiment/queue/", response_model=Dict[int])
+async def get_experiment_queue() -> Dict[int]:
+    """Gets the list of queued experiment and returns it.
 
     Returns:
         A dictionary of queued experiments with rid as their keys.
+        The value of each corresponding rid is a dictionary with several information:
+          "priority", "status", "flush", "pipeline", "expid", and etc.
         It includes the running experiment with different "status" value.
     """
     remote = get_client("master_schedule")
-    current_experiment = remote.get_status()
-    return current_experiment
+    return remote.get_status()
 
 
 @app.get("/experiment/code/")

--- a/main.py
+++ b/main.py
@@ -98,14 +98,16 @@ async def get_experiment_info(file: str) -> Any:
 
 previous_queue = {}
 current_queue = {}
-@app.get("/experiment/queue/", response_model=Dict[int, Dict[str, Any]])
+
+
+@app.get("/experiment/queue/")
 async def get_experiment_queue() -> Dict[int, Dict[str, Any]]:
     """Gets the list of queued experiment and returns it.
 
     Returns:
         A dictionary of queued experiments with rid as their keys.
         The value of each corresponding rid is a dictionary with several information:
-          "priority", "status", "flush", "pipeline", "expid", and etc.
+          "priority", "status", "due_date", "pipeline", "expid", etc.
         It includes the running experiment with different "status" value.
     """
     remote = get_client("master_schedule")

--- a/main.py
+++ b/main.py
@@ -97,7 +97,6 @@ async def get_experiment_info(file: str) -> Any:
 
 
 previous_queue = {}
-current_queue = {}
 
 
 @app.get("/experiment/queue/")
@@ -111,6 +110,7 @@ async def get_experiment_queue() -> Dict[int, Dict[str, Any]]:
         It includes the running experiment with different "status" value.
     """
     remote = get_client("master_schedule")
+    current_queue = previous_queue
     while current_queue == previous_queue:
         await asyncio.sleep(0)
         current_queue.clear()

--- a/main.py
+++ b/main.py
@@ -95,8 +95,8 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
-@app.get("/experiment/queue/", response_model=Dict[int])
-async def get_experiment_queue() -> Dict[int]:
+@app.get("/experiment/queue/", response_model=Dict[int, Dict])
+async def get_experiment_queue() -> Dict[int, Dict]:
     """Gets the list of queued experiment and returns it.
 
     Returns:


### PR DESCRIPTION
The function `get_experiment_queue()` returns a dictionary like:
```
{'167': {'pipeline': 'main', 'expid': {'log_level': 30, 'class_name': None, 'arguments': {'user': 'QuIQCL', 'time': 1.0, 'save': False, 'color': 'r'}, 'file': 'DIRECTORY-PATH'}, 'priority': 1, 'due_date': None, 'flush': False, 'status': 'analyzing', 'repo_msg': None}, 
 '168': {'pipeline': 'main', 'expid': {'log_level': 30, 'class_name': None, 'arguments': {'user': 'QuIQCL', 'time': 1.0, 'save': False, 'color': 'r'}, 'file': 'DIRECTORY-PATH'}, 'priority': 1, 'due_date': None, 'flush': False, 'status': 'pending', 'repo_msg': None}, 
 '169': {'pipeline': 'main', 'expid': {'log_level': 30, 'class_name': None, 'arguments': {'user': 'QuIQCL', 'time': 1.0, 'save': False, 'color': 'r'}, 'file': 'DIRECTORY-PATH'}, 'priority': 1, 'due_date': None, 'flush': False, 'status': 'pending', 'repo_msg': None}, 
 '170': {'pipeline': 'main', 'expid': {'log_level': 30, 'class_name': None, 'arguments': {'user': 'QuIQCL', 'time': 1.0, 'save': False, 'color': 'r'}, 'file': 'DIRECTORY-PATH'}, 'priority': 1, 'due_date': None, 'flush': False, 'status': 'pending', 'repo_msg': None}}
```

which is the dictionary of scheduled experiments, whose keys are the`rid`value.

This dictionary is fetched from `scheduler.py` (introduced in issue [#72](https://github.com/snu-quiqcl/iquip/issues/72) in`iquip`and pull request [#91](https://github.com/snu-quiqcl/iquip/pull/91)) to display these experiments.

This closes #29.