### PR TITLE
A `scheduler` replica

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,22 +109,22 @@ async def get_experiment_code(file: str) -> str:
 
 
 @app.post("/experiment/delete/")
-async def delete_experiment(rid):
+async def delete_experiment(rid: int):
     """Kills the run with the specified RID.
 
     Args:
-        rid: rid value of the target experiment.
+        rid: The run identifier value of the target experiment.
     """
     remote = get_client("master_schedule")
     remote.delete(rid)
 
 
 @app.post("/experiment/request_termination/")
-async def request_termination_of_experiment(rid):
+async def request_termination_of_experiment(rid: int):
     """Requests graceful termination of the run with the specified RID.
 
     Args:
-        rid: rid value of the target experiment.
+        rid: The run identifier value of the target experiment.
     """
     remote = get_client("master_schedule")
     remote.request_termination(rid)

--- a/main.py
+++ b/main.py
@@ -110,14 +110,22 @@ async def get_experiment_code(file: str) -> str:
 
 @app.post("/experiment/delete/")
 async def delete_experiment(rid):
-    """Kills the run with the specified RID."""
+    """Kills the run with the specified RID.
+
+    Args:
+        rid: rid value of the target experiment.
+    """
     remote = get_client("master_schedule")
     remote.delete(rid)
 
 
 @app.post("/experiment/request_termination/")
-async def delete_experiment(rid):
-    """Requests graceful termination of the run with the specified RID."""
+async def request_termination_of_experiment(rid):
+    """Requests graceful termination of the run with the specified RID.
+
+    Args:
+        rid: rid value of the target experiment.
+    """
     remote = get_client("master_schedule")
     remote.request_termination(rid)
 

--- a/main.py
+++ b/main.py
@@ -97,19 +97,6 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
-@app.get("/experiment/code/")
-async def get_experiment_code(file: str) -> str:
-    """Gets code of the given experiment file and returns it.
-    
-    Args:
-        file: The path of the experiment file.
-    """
-    full_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
-    with open(full_path, encoding="utf-8") as experiment_file:
-        code = experiment_file.read()
-    return code
-
-
 @app.post("/experiment/delete/")
 async def delete_experiment(rid: int):
     """Kills the run with the specified RID.

--- a/main.py
+++ b/main.py
@@ -108,6 +108,20 @@ async def get_experiment_code(file: str) -> str:
     return code
 
 
+@app.post("/experiment/delete/")
+async def delete_experiment(rid):
+    """Kills the run with the specified RID."""
+    remote = get_client("master_schedule")
+    remote.delete(rid)
+
+
+@app.post("/experiment/request_termination/")
+async def delete_experiment(rid):
+    """Requests graceful termination of the run with the specified RID."""
+    remote = get_client("master_schedule")
+    remote.request_termination(rid)
+
+
 @app.get("/experiment/submit/")
 async def submit_experiment(
     file: str,

--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ async def delete_experiment(rid: int):
     remote.delete(rid)
 
 
-@app.post("/experiment/request_termination/")
+@app.post("/experiment/terminate/")
 async def request_termination_of_experiment(rid: int):
     """Requests graceful termination of the run with the specified RID.
 


### PR DESCRIPTION
It is a simple replica of a `scheduler` in [`artiq/master/scheduler.py`](https://github.com/m-labs/artiq/blob/master/artiq/master/scheduler.py#L400) to receive signals to delete experiments and request termination of experiments from our GUI.

There are two functions implemented:
`delete_experiment(rid)`: Kills the run with the specified RID.
`request_termination_of_experiment(rid)`: Requests graceful termination of the run with the specified RID.

Both are already defined as a method of `Scheduler` instance in [`artiq/master/scheduler.py`](https://github.com/m-labs/artiq/blob/master/artiq/master/scheduler.py#L400) and above two calls each one.

This closes #44.