### PR TITLE
Modify an experiment to make logs and vcd file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
-    "visualize_path": "visualize/"
+    "result_path": "results/"
 }

--- a/main.py
+++ b/main.py
@@ -201,7 +201,7 @@ import posixpath
     # make logs to track each line
     run_func_stmt.body = add_tracking_line(run_func_stmt.body)
     # call write_vcd()
-    write_vcd_call_stmt = ast.parse("write_vcd()").body
+    write_vcd_call_stmt = ast.parse("self.write_vcd()").body
     run_func_stmt.body.append(write_vcd_call_stmt)
     # define write_vcd()
     write_vcd_func_code = f"""

--- a/main.py
+++ b/main.py
@@ -160,6 +160,9 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
 
 def modify_experiment_code(code: str, experiment_cls_name: str):
     code_mod = ast.parse(code)
+    # import subprocess module
+    import_subprocess_stmt = ast.parse("import subprocess").body
+    code_mod.body.insert(0, import_subprocess_stmt)
     experiment_cls_stmt = next(
         stmt for stmt in code_mod.body
         if isinstance(stmt, ast.ClassDef) and stmt.name == experiment_cls_name

--- a/main.py
+++ b/main.py
@@ -151,6 +151,10 @@ def modify_experiment_code(code: str, experiment_cls_name: str):
         stmt for stmt in code_ast.body
         if isinstance(stmt, ast.ClassDef) and stmt.name == experiment_cls_name
     )
+    run_func_ast = next(
+        stmt for stmt in experiment_cls_ast.body
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
+    )
     return ast.unparse(code_ast)
 
 

--- a/main.py
+++ b/main.py
@@ -184,16 +184,16 @@ def modify_experiment_code(code: str, experiment_cls_name: str) -> str:
     Returns:
         The modified experiment code.
     """
-    code_mod = ast.parse(code)
+    mod = ast.parse(code)
     # import modules
     import_code = """
 import subprocess
 import posixpath
     """
     import_stmt = ast.parse(import_code).body
-    code_mod.body = import_stmt + code_mod.body
+    mod.body = import_stmt + mod.body
     experiment_cls_stmt = next(
-        stmt for stmt in code_mod.body
+        stmt for stmt in mod.body
         if isinstance(stmt, ast.ClassDef) and stmt.name == experiment_cls_name
     )
     run_func_stmt = next(
@@ -225,7 +225,7 @@ def write_vcd(self):
     """
     write_vcd_func_stmt = ast.parse(write_vcd_func_code).body
     experiment_cls_stmt.body.append(write_vcd_func_stmt)
-    return ast.unparse(code_mod)
+    return ast.unparse(mod)
 
 
 @app.get("/experiment/submit/")

--- a/main.py
+++ b/main.py
@@ -146,6 +146,16 @@ async def request_termination_of_experiment(rid: int):
 
 
 def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
+    """Modifies the given statements list to leave rtio logs that track each line.
+
+    Adds logs containing the corresponding line number before each line, recursively.
+
+    Args:
+        stmt_list: The list of ast statements.
+
+    Returns:
+        The list of modified ast statements.
+    """
     modified_stmt_list = []
     for stmt in stmt_list:
         tracking_line_code = f"rtio_log('line', {stmt.lineno})"
@@ -158,7 +168,20 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
     return modified_stmt_list
 
 
-def modify_experiment_code(code: str, experiment_cls_name: str):
+def modify_experiment_code(code: str, experiment_cls_name: str) -> str:
+    """Modifies the given code to leave rtio logs and make the vcd file.
+
+    It performs the following modifications:
+        1. Add the rtio logs to track each line.
+        2. Make the vcd file into the corresponding path.
+
+    Args:
+        code: The experiment code.
+        experiment_cls_name: The class name of the experiment.
+
+    Returns:
+        The modified experiment code.
+    """
     code_mod = ast.parse(code)
     # import modules
     import_code = """

--- a/main.py
+++ b/main.py
@@ -168,7 +168,18 @@ def modify_experiment_code(code: str, experiment_cls_name: str):
         stmt for stmt in experiment_cls_stmt.body
         if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
     )
+    # make logs to track each line
     run_func_stmt.body = add_tracking_line(run_func_stmt.body)
+    # call write_vcd()
+    write_vcd_call_stmt = ast.parse("write_vcd()").body
+    run_func_stmt.body.append(write_vcd_call_stmt)
+    # define write_vcd()
+    write_vcd_func_code = """
+def write_vcd(self):
+    pass
+    """
+    write_vcd_func_stmt = ast.parse(write_vcd_func_code).body
+    experiment_cls_stmt.body.append(write_vcd_func_stmt)
     return ast.unparse(code_mod)
 
 

--- a/main.py
+++ b/main.py
@@ -205,17 +205,15 @@ def modify_experiment_code(code: str, experiment_cls_name: str) -> str:
     run_func_stmt.body.append(write_vcd_call_stmt)
     # define write_vcd()
     device_db_path = posixpath.join(configs["master_path"], "device_db.py")
+    vcd_path = posixpath.join(configs["master_path"], configs["result_path"], "{rid}/rtio.vcd")
     write_vcd_func_code = f"""
 def write_vcd(self):
     result = subprocess.run("curl http://127.0.0.1:8000/experiment/running/",
                             capture_output=True, shell=True, text=True)
     rid = int(result.stdout)
-    vcd_path = posixpath.join(
-        "{configs["master_path"]}",
-        "{configs["result_path"]}",
-        f"{{rid}}/rtio.vcd"
-    )
-    subprocess.run(f"artiq_coreanalyzer --device-db {device_db_path} -w {{vcd_path}}",
+    device_db_path = "{device_db_path}"
+    vcd_path = f"{vcd_path}"
+    subprocess.run(f"artiq_coreanalyzer --device-db {{device_db_path}} -w {{vcd_path}}",
                    capture_output=True, shell=True)
     """
     write_vcd_func_stmt = ast.parse(write_vcd_func_code).body

--- a/main.py
+++ b/main.py
@@ -161,17 +161,17 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
 
 
 def modify_experiment_code(code: str, experiment_cls_name: str):
-    code_ast = ast.parse(code)
+    code_mod = ast.parse(code)
     experiment_cls_ast = next(
-        stmt for stmt in code_ast.body
+        stmt for stmt in code_mod.body
         if isinstance(stmt, ast.ClassDef) and stmt.name == experiment_cls_name
     )
-    run_func_ast = next(
+    run_func_stmt = next(
         stmt for stmt in experiment_cls_ast.body
         if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
     )
-    run_func_ast.body = add_tracking_line(run_func_ast.body)
-    return ast.unparse(code_ast)
+    run_func_stmt.body = add_tracking_line(run_func_stmt.body)
+    return ast.unparse(code_mod)
 
 
 @app.get("/experiment/submit/")

--- a/main.py
+++ b/main.py
@@ -150,6 +150,7 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
     """Returns the statements list created to leave rtio logs that track each line.
 
     Adds logs containing the corresponding line number before each line, recursively.
+    The given statements list is not modified.
 
     Args:
         stmt_list: The list of ast statements.

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ def load_config_file():
       {
         "master_path": {master_path}
         "repository_path": {repository_path}
+        "result_path": {result_path}
       }
     """
     with open("config.json", encoding="utf-8") as config_file:

--- a/main.py
+++ b/main.py
@@ -209,12 +209,16 @@ def write_vcd(self):
     result = subprocess.run("curl http://127.0.0.1:8000/experiment/running/",
                             capture_output=True, shell=True, text=True)
     rid = int(result.stdout)
+    device_db_path = posixpath.join(
+        "{configs["master_path"]}",
+        "device_db.py"
+    )
     vcd_path = posixpath.join(
         "{configs["master_path"]}",
         "{configs["visualize_path"]}",
         f"{{rid}}/rtio.log"
     )
-    subprocess.run("artiq_coreanalyzer -w f'{{vcd_path}}'",
+    subprocess.run("artiq_coreanalyzer --device-db f'{{device_db_path}}' -w f'{{vcd_path}}'",
                    capture_output=True, shell=True)
     """
     write_vcd_func_stmt = ast.parse(write_vcd_func_code).body

--- a/main.py
+++ b/main.py
@@ -201,10 +201,12 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
             "args": args_dict,
             "pipeline": pipeline,
             "priority": priority,
-            "submission_time": datetime.now().isoformat()
+            "timed": timed,
+            "submission_time": datetime.now().isoformat(timespec="seconds")
         }
-        if timed is not None:
-            metadata["timed"] = timed
+        metadata_path = posixpath.join(visualize_dir_path, "metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as metadata_file:
+            json.dump(metadata, metadata_file)
     return rid
 
 

--- a/main.py
+++ b/main.py
@@ -147,7 +147,7 @@ async def request_termination_of_experiment(rid: int):
 
 
 def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
-    """Modifies the given statements list to leave rtio logs that track each line.
+    """Returns the statements list created to leave rtio logs that track each line.
 
     Adds logs containing the corresponding line number before each line, recursively.
 
@@ -155,7 +155,7 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
         stmt_list: The list of ast statements.
 
     Returns:
-        The list of modified ast statements.
+        The created list of ast statements.
     """
     modified_stmt_list = []
     for stmt in stmt_list:

--- a/main.py
+++ b/main.py
@@ -148,7 +148,9 @@ async def request_termination_of_experiment(rid: int):
 def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
     modified_stmt_list = []
     for stmt in stmt_list:
-        modified_stmt_list.append(ast.Expr(value=ast.Constant(value=1)))
+        tracking_line_code = f"rtio_log('line', {stmt.lineno})"
+        tracking_line_stmt = ast.parse(tracking_line_code).body
+        modified_stmt_list.extend(tracking_line_stmt)
         for attr in ("body", "handlers", "orelse", "finalbody"):
             if hasattr(stmt, attr):
                 setattr(stmt, attr, add_tracking_line(getattr(stmt, attr)))

--- a/main.py
+++ b/main.py
@@ -202,18 +202,17 @@ def write_vcd(self):
 @app.get("/experiment/submit/")
 async def submit_experiment(  # pylint: disable=too-many-arguments
     file: str,
-    cls: str,
     args: str = "{}",
     pipeline: str = "main",
     priority: int = 0,
     timed: Optional[str] = None,
-    visualize: bool = False
+    visualize: bool = False,
+    cls: str = ""
 ) -> int:
     """Submits the given experiment file.
     
     Args:
         file: The path of the experiment file.
-        cls: The class name of the experiment.
         args: The arguments to submit which must be a JSON string of a dictionary.
           Each key is an argument name and its value is the value of the argument.
         pipeline: The pipeline to run the experiment in.
@@ -222,6 +221,8 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
           None for no due date.
         visualize: If True, the experiment file is modified for visualization.
           The original file and vcd file are saved in the visualize path set in config.json.
+        cls: The class name of the experiment.
+          It is only necessary when the visualize argument is True.
     
     Returns:
         The run identifier, an integer which is incremented at each experiment submission.

--- a/main.py
+++ b/main.py
@@ -177,6 +177,8 @@ def modify_experiment_code(code: str, experiment_cls_name: str) -> str:
         1. Add the rtio logs to track each line.
         2. Make the vcd file into the corresponding path.
 
+    It assumes that the code contains an experiment class and run() method.
+
     Args:
         code: The experiment code.
         experiment_cls_name: The class name of the experiment.

--- a/main.py
+++ b/main.py
@@ -267,14 +267,13 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
             modified_experiment_file.write(modified_code)
         submission_file_path = modified_experiment_path
     else:
-        # TODO(BECATRUE): The exact experiment path will be assigned in #37.
-        pass
+        submission_file_path = posixpath.join(configs["repository_path"], file)
     args_dict = json.loads(args)
     expid = {
         "log_level": logging.WARNING,
         "class_name": None,
         "arguments": args_dict,
-        "file": posixpath.join(configs["repository_path"], file)
+        "file": submission_file_path
     }
     due_date = None if timed is None else time.mktime(datetime.fromisoformat(timed).timetuple())
     remote = get_client("master_schedule")

--- a/main.py
+++ b/main.py
@@ -228,11 +228,24 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
         The run identifier, an integer which is incremented at each experiment submission.
     """
     if visualize:
+        visualize_dir_path = posixpath.join(
+            configs["master_path"],
+            configs["visualize_path"],
+            f"{rid}/"
+        )
+        os.makedirs(visualize_dir_path)
         experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
+        # copy the original experiment file
+        copied_experiment_path = posixpath.join(visualize_dir_path, "experiment.py")
+        shutil.copyfile(experiment_path, copied_experiment_path)
+        # modify the experiment code
         with open(experiment_path, encoding="utf-8") as experiment_file:
             code = experiment_file.read()
         modified_code = modify_experiment_code(code, cls)
-        print(modified_code)
+        # save the modified experiment code
+        modified_experiment_path = posixpath.join(visualize_dir_path, "modified_experiment.py")
+        with open(modified_experiment_path, "w", encoding="utf-8") as modified_experiment_file:
+            modified_experiment_file.write(modified_code)
     else:
         # TODO(BECATRUE): The exact experiment path will be assigned in #37.
         pass
@@ -247,14 +260,6 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
     remote = get_client("master_schedule")
     rid = remote.submit(pipeline, expid, priority, due_date, False)
     if visualize:
-        visualize_dir_path = posixpath.join(
-            configs["master_path"],
-            configs["visualize_path"],
-            f"{rid}/"
-        )
-        os.makedirs(visualize_dir_path)
-        copied_experiment_path = posixpath.join(visualize_dir_path, "experiment.py")
-        shutil.copyfile(experiment_path, copied_experiment_path)
         metadata = {
             "file": experiment_path,
             "args": args_dict,

--- a/main.py
+++ b/main.py
@@ -216,7 +216,7 @@ def write_vcd(self):
     )
     vcd_path = posixpath.join(
         "{configs["master_path"]}",
-        "{configs["visualize_path"]}",
+        "{configs["result_path"]}",
         f"{{rid}}/rtio.vcd"
     )
     subprocess.run(f"artiq_coreanalyzer --device-db {{device_db_path}} -w {{vcd_path}}",
@@ -256,11 +256,11 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
         The run identifier, an integer which is incremented at each experiment submission.
     """
     submission_time = datetime.now().isoformat(timespec="seconds")
-    visualize_dir_path = posixpath.join(configs["master_path"], configs["visualize_path"])
+    result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
     if visualize:
         experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
         modified_experiment_path = posixpath.join(
-            visualize_dir_path,
+            result_dir_path,
             f"experiment_{submission_time}.py"
         )
         # modify the experiment code
@@ -284,7 +284,7 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
     remote = get_client("master_schedule")
     rid = remote.submit(pipeline, expid, priority, due_date, False)
     # make the RID directory
-    rid_dir_path = posixpath.join(visualize_dir_path, f"{rid}/")
+    rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
     os.makedirs(rid_dir_path)
     # save the metadata
     metadata = {

--- a/main.py
+++ b/main.py
@@ -162,12 +162,12 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
 
 def modify_experiment_code(code: str, experiment_cls_name: str):
     code_mod = ast.parse(code)
-    experiment_cls_ast = next(
+    experiment_cls_stmt = next(
         stmt for stmt in code_mod.body
         if isinstance(stmt, ast.ClassDef) and stmt.name == experiment_cls_name
     )
     run_func_stmt = next(
-        stmt for stmt in experiment_cls_ast.body
+        stmt for stmt in experiment_cls_stmt.body
         if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
     )
     run_func_stmt.body = add_tracking_line(run_func_stmt.body)

--- a/main.py
+++ b/main.py
@@ -145,6 +145,14 @@ async def request_termination_of_experiment(rid: int):
     remote.request_termination(rid)
 
 
+def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
+    modified_stmt_list = []
+    for stmt in stmt_list:
+        modified_stmt_list.append(ast.Expr(value=ast.Constant(value=1)))
+        modified_stmt_list.append(stmt)
+    return modified_stmt_list
+
+
 def modify_experiment_code(code: str, experiment_cls_name: str):
     code_ast = ast.parse(code)
     experiment_cls_ast = next(
@@ -155,6 +163,7 @@ def modify_experiment_code(code: str, experiment_cls_name: str):
         stmt for stmt in experiment_cls_ast.body
         if isinstance(stmt, ast.FunctionDef) and stmt.name == "run"
     )
+    run_func_ast.body = add_tracking_line(run_func_ast.body)
     return ast.unparse(code_ast)
 
 

--- a/main.py
+++ b/main.py
@@ -216,7 +216,7 @@ def write_vcd(self):
     vcd_path = posixpath.join(
         "{configs["master_path"]}",
         "{configs["visualize_path"]}",
-        f"{{rid}}/rtio.log"
+        f"{{rid}}/rtio.vcd"
     )
     subprocess.run(f"artiq_coreanalyzer --device-db {{device_db_path}} -w {{vcd_path}}",
                    capture_output=True, shell=True)

--- a/main.py
+++ b/main.py
@@ -177,10 +177,11 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
     else:
         # TODO(BECATRUE): The exact experiment path will be assigned in #37.
         pass
+    args_dict = json.loads(args)
     expid = {
         "log_level": logging.WARNING,
         "class_name": None,
-        "arguments": json.loads(args),
+        "arguments": args_dict,
         "file": posixpath.join(configs["repository_path"], file)
     }
     due_date = None if timed is None else time.mktime(datetime.fromisoformat(timed).timetuple())
@@ -195,6 +196,15 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
         os.makedirs(visualize_dir_path)
         copied_experiment_path = posixpath.join(visualize_dir_path, "experiment.py")
         shutil.copyfile(experiment_path, copied_experiment_path)
+        metadata = {
+            "file": experiment_path,
+            "args": args_dict,
+            "pipeline": pipeline,
+            "priority": priority,
+            "submission_time": datetime.now().isoformat()
+        }
+        if timed is not None:
+            metadata["timed"] = timed
     return rid
 
 

--- a/main.py
+++ b/main.py
@@ -149,6 +149,9 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
     modified_stmt_list = []
     for stmt in stmt_list:
         modified_stmt_list.append(ast.Expr(value=ast.Constant(value=1)))
+        for attr in ("body", "handlers", "orelse", "finalbody"):
+            if hasattr(stmt, attr):
+                setattr(stmt, attr, add_tracking_line(getattr(stmt, attr)))
         modified_stmt_list.append(stmt)
     return modified_stmt_list
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import time
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import pydantic
 from fastapi import FastAPI
@@ -227,7 +227,7 @@ def write_vcd(self):
 
 
 @app.get("/experiment/submit/")
-async def submit_experiment(  # pylint: disable=too-many-arguments
+async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-locals
     file: str,
     args: str = "{}",
     pipeline: str = "main",

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import time
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pydantic
 from fastapi import FastAPI
@@ -154,8 +154,6 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
         for attr in ("body", "handlers", "orelse", "finalbody"):
             if hasattr(stmt, attr):
                 setattr(stmt, attr, add_tracking_line(getattr(stmt, attr)))
-        if isinstance(stmt, ast.ExceptHandler):
-            stmt.body = add_tracking_line(stmt.body)
         modified_stmt_list.append(stmt)
     return modified_stmt_list
 

--- a/main.py
+++ b/main.py
@@ -152,6 +152,8 @@ def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
         for attr in ("body", "handlers", "orelse", "finalbody"):
             if hasattr(stmt, attr):
                 setattr(stmt, attr, add_tracking_line(getattr(stmt, attr)))
+        if isinstance(stmt, ast.ExceptHandler):
+            stmt.body = add_tracking_line(stmt.body)
         modified_stmt_list.append(stmt)
     return modified_stmt_list
 

--- a/main.py
+++ b/main.py
@@ -172,7 +172,7 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
     if visualize:
         experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
         with open(experiment_path, encoding="utf-8") as experiment_file:
-            _code = experiment_file.read()
+            code = experiment_file.read()
         # TODO(BECATRUE): The code will be modifed in #37.
     else:
         # TODO(BECATRUE): The exact experiment path will be assigned in #37.

--- a/main.py
+++ b/main.py
@@ -147,7 +147,7 @@ async def request_termination_of_experiment(rid: int):
 
 
 def add_tracking_line(stmt_list: List[ast.stmt]) -> List[ast.stmt]:
-    """Returns the statements list created to leave rtio logs that track each line.
+    """Returns a new statements list interleaved with rtio logs for tracking each line.
 
     Adds logs containing the corresponding line number before each line, recursively.
     The given statements list is not modified.

--- a/main.py
+++ b/main.py
@@ -218,7 +218,7 @@ def write_vcd(self):
         "{configs["visualize_path"]}",
         f"{{rid}}/rtio.log"
     )
-    subprocess.run("artiq_coreanalyzer --device-db f'{{device_db_path}}' -w f'{{vcd_path}}'",
+    subprocess.run(f"artiq_coreanalyzer --device-db {{device_db_path}} -w {{vcd_path}}",
                    capture_output=True, shell=True)
     """
     write_vcd_func_stmt = ast.parse(write_vcd_func_code).body

--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ async def submit_experiment(  # pylint: disable=too-many-arguments
         experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
         with open(experiment_path, encoding="utf-8") as experiment_file:
             code = experiment_file.read()
-        # TODO(BECATRUE): The code will be modifed in #37.
+        modified_code = modify_experiment_code(code)
     else:
         # TODO(BECATRUE): The exact experiment path will be assigned in #37.
         pass


### PR DESCRIPTION
This PR will close #37 and close #42.

Fisrt of all, I apologize for the long and convoluted code😅

I implemented the following two main features:
1. Modify the experiment to make logs and vcd file using [`ast`](https://docs.python.org/3/library/ast.html) library.
2. Save the submission time into the metadata file.

# Overall procedure
1. Read the original file and modify it by `modify_experiment_code()`.
2. Save the modified experiment in `{visualize_path}/experiment_{submission_time}.py`.
This file will be moved in `{visualize_path}/{rid}/modified_experiment.py` after fetching the result directory.
#38
3. Submit the modified experiment with the corresponding experiment path.
The vcd file is created in `{visualize_path}/{rid}/rtio.vcd`.
4. Make the visualize result directory with the path `{visualize_path}/{rid}/`.
5. Save the metadata in `{visualize_path}/{rid}/metadata.json`.

# Modify the experiment
This uses `ast` library basically.

To leave an rtio log, I used [`rtio_log`](https://m-labs.hk/artiq/manual/getting_started_core.html#rtio-analyzer-example).
All logs are created just before each line in `run()`, and contain the line number information.

To make a vcd file, I used [`artiq_coreanalyzer`](https://m-labs.hk/artiq/manual/utilities.html#core-device-rtio-analyzer-tool).
This feature is written in `write_vcd()`.

For example, the original code is as follows.
```python
from artiq.experiment import *

class TTLWave(EnvExperiment):
    """Simple TTL pulses"""

    def build(self):
        self.setattr_device("core")
        self.setattr_device("ttl4")
        self.dds0 = self.get_device("urukul0_ch0")
        self.setattr_argument("count", NumberValue(default=3, min=1, max=1000, ndecimals=0, scale=1, step=1, type="int"))
        self.setattr_argument("time", NumberValue(default=10*10**-3, min=1*10**-3, max=1, unit="ms"))

    @kernel
    def run(self):
        self.core.reset()
        for i in range(self.count):
            self.ttl4.on()
            delay(self.time)
            self.ttl4.off()
            delay(self.time)
```

The modified code is as follows:
```python
import subprocess
import posixpath
from artiq.experiment import *

class TTLWave(EnvExperiment):
    """Simple TTL pulses"""

    def build(self):
        self.setattr_device('core')
        self.setattr_device('ttl4')
        self.dds0 = self.get_device('urukul0_ch0')
        self.setattr_argument('count', NumberValue(default=3, min=1, max=1000, ndecimals=0, scale=1, step=1, type='int'))
        self.setattr_argument('time', NumberValue(default=10 * 10 ** (-3), min=1 * 10 ** (-3), max=1, unit='ms'))

    @kernel
    def run(self):
        rtio_log('line', 15)
        self.core.reset()
        rtio_log('line', 16)
        for i in range(self.count):
            rtio_log('line', 17)
            self.ttl4.on()
            rtio_log('line', 18)
            delay(self.time)
            rtio_log('line', 19)
            self.ttl4.off()
            rtio_log('line', 20)
            delay(self.time)
        self.write_vcd()

    def write_vcd(self):
        result = subprocess.run('curl http://127.0.0.1:8000/experiment/running/', capture_output=True, shell=True, text=True)
        rid = int(result.stdout)
        device_db_path = posixpath.join('/home/rabi/artiq/', 'device_db.py')
        vcd_path = posixpath.join('/home/rabi/artiq/', 'visualize/', f'{rid}/rtio.vcd')
        subprocess.run(f'artiq_coreanalyzer --device-db {device_db_path} -w {vcd_path}', capture_output=True, shell=True)
```

# Save the metadata file
After each submission, the submission time is saved in `{visualize_path}/{rid}/metadata.json`.

An example file is as follows:
```json
{"submission_time": "2023-08-13T14:51:51"}
```

The information contained is small, but it can be expanded later, so I saved it as json.

# Result
## Visualize directory structure
The visualize path is set to `visualize/` in `config.json` and the directory is created in the artiq-master path.

The directory structure is as follows.

<img width="80%" src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/49c331ef-42c1-4c6e-ac85-344166c8a702">

## VCD file
According to the above experiment file, it will make three pulses and leave the logs with the line number 18 (1st delay) and 20 (2nd delay).

<img src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/0bc15f52-f8db-44cf-b94d-f8a25285be96">

# Note
The modified experiment __CANNOT__ be performed in an environment using an ARTIQ simulator.
To run `rtio_log()`, you should run this with the actual ARTIQ devices.