### PR TITLE
Send the result directory structure

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,6 +21,7 @@ jobs:
         pip install pylint
     - name: Add dependencies about external libraries
       run: |
+        pip install h5py
         pip install fastapi
         pip install git+https://github.com/m-labs/sipyco.git
     - name: Analyze the code with pylint

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,6 +21,7 @@ jobs:
         pip install coverage
     - name: Add dependencies about external libraries
       run: |
+        pip install h5py
         pip install fastapi
         pip install httpx
         pip install numpy

--- a/main.py
+++ b/main.py
@@ -337,8 +337,11 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
     rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
     # read the metadata
     metadata_path = posixpath.join(rid_dir_path, "metadata.json")
-    with open(metadata_path, encoding="utf-8") as metadata_file:
-        metadata = json.load(metadata_file)
+    try:
+        with open(metadata_path, encoding="utf-8") as metadata_file:
+            metadata = json.load(metadata_file)
+    except OSError:
+        return False
     submission_time_str, visualize = metadata["submission_time"], metadata["visualize"]
     submission_time = datetime.fromisoformat(submission_time_str)
     date = submission_time.date().isoformat()

--- a/main.py
+++ b/main.py
@@ -417,7 +417,7 @@ async def list_result_directory() -> List[int]:
             rid = item[1:]
             if organize_result_directory(result_dir_path, rid):
                 rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
-                shutil.move(item_path, rid_dir_path)
+                os.rename(item_path, rid_dir_path)
     # find all organized RID directories
     rid_list = []
     for item in os.listdir(result_dir_path):

--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def modify_experiment_code(code: str, experiment_cls_name: str) -> str:
     run_func_stmt.body.append(write_vcd_call_stmt)
     # define write_vcd()
     device_db_path = posixpath.join(configs["master_path"], "device_db.py")
-    vcd_path = posixpath.join(configs["master_path"], configs["result_path"], "{rid}/rtio.vcd")
+    vcd_path = posixpath.join(configs["master_path"], configs["result_path"], "_{rid}/rtio.vcd")
     write_vcd_func_code = f"""
 def write_vcd(self):
     result = subprocess.run("curl http://127.0.0.1:8000/experiment/running/",

--- a/main.py
+++ b/main.py
@@ -321,11 +321,15 @@ def organize_result_directory(result_dir_path: str, rid: str):
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = json.load(metadata_file)
     os.remove(metadata_path)
-    # find the result file
     submission_time_str = metadata["submission_time"]
     submission_time = datetime.fromisoformat(submission_time_str)
     date = submission_time.date().isoformat()
     hour = submission_time.hour
+    # move the modified experiment file to the RID directory
+    experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
+    moved_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
+    shutil.move(experiment_path, moved_experiment_path)
+    # find the result file
     datetime_result_dir_path = posixpath.join(result_dir_path, f"{date}/{hour}/")
     padded_rid = rid.zfill(9)
     for item in os.listdir(datetime_result_dir_path):
@@ -334,11 +338,11 @@ def organize_result_directory(result_dir_path: str, rid: str):
     else:  # no result file
         return
     # copy the result file to the RID directory
-    item_path = posixpath.join(datetime_result_dir_path, item)
-    result_path = posixpath.join(rid_dir_path, "result.h5")
-    shutil.copyfile(item_path, result_path)
+    result_path = posixpath.join(datetime_result_dir_path, item)
+    copied_result_path = posixpath.join(rid_dir_path, "result.h5")
+    shutil.copyfile(result_path, copied_result_path)
     # modify the result file
-    with h5py.File(result_path, "a") as result_file:
+    with h5py.File(copied_result_path, "a") as result_file:
         submission_time_dataset = result_file.create_dataset(
             "submission_time", (1,), dtype=h5py.string_dtype(encoding="utf-8")
         )

--- a/main.py
+++ b/main.py
@@ -328,7 +328,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
 
     Args:
         result_dir_path: The full path of the result directory.
-        rid: The RID string.
+        rid: The run identifier value of the experiment in string.
 
     Returns:
         True if the h5 result file exists.

--- a/main.py
+++ b/main.py
@@ -324,6 +324,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         2. Move the modified experiment to the RID directory.
         3. Find the h5 result file and copy it to the RID directory.
         4. Dump the metadata on the copied result file.
+        5. Remove the metadata file.
 
     Args:
         result_dir_path: The full path of the result directory.

--- a/main.py
+++ b/main.py
@@ -407,18 +407,21 @@ async def list_result_directory() -> List[int]:
     Returns:
         A list with RIDs of the executed experiments, sorted in an ascending order.
     """
-    rid_list = []
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
-    # navigate to each RID directory
+    # navigate to each RID directory not organized yet
     for item in os.listdir(result_dir_path):
         item_path = posixpath.join(result_dir_path, item)
-        # find a RID directory not organized yet
         if posixpath.isdir(item_path) and item.startswith("_") and item[1:].isdigit():
             rid = item[1:]
             if organize_result_directory(result_dir_path, rid):
-                rid_list.append(int(rid))
                 rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
                 shutil.move(item_path, rid_dir_path)
+    # find all organized RID directories
+    rid_list = []
+    for item in os.listdir(result_dir_path):
+        item_path = posixpath.join(result_dir_path, item)
+        if posixpath.isdir(item_path) and item.isdigit():
+            rid_list.append(int(item))
     rid_list.sort()
     return rid_list
 

--- a/main.py
+++ b/main.py
@@ -316,10 +316,11 @@ async def get_running_experiment() -> Optional[int]:
 
 def organize_result_directory(result_dir_path: str, rid: str):
     rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
-    # read the metadata
+    # read and remove the metadata
     metadata_path = posixpath.join(rid_dir_path, "metadata.json")
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = json.load(metadata_file)
+    os.remove(metadata_path)
     # find the result file
     submission_time_str = metadata["submission_time"]
     submission_time = datetime.fromisoformat(submission_time_str)

--- a/main.py
+++ b/main.py
@@ -313,6 +313,11 @@ async def get_running_experiment() -> Optional[int]:
     return None
 
 
+@app.get("/result/")
+async def list_result_directory() -> List[str]:
+    pass
+
+
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.
 

--- a/main.py
+++ b/main.py
@@ -397,10 +397,10 @@ async def list_result_directory() -> List[int]:
         # find a RID directory not organized yet
         if posixpath.isdir(item_path) and item.startswith("_") and item[1:].isdigit():
             rid = item[1:]
-            rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
-            shutil.move(item_path, rid_dir_path)
-            if organize_result_directory(result_dir_path, item):
-                rid_list.append(rid)
+            if organize_result_directory(result_dir_path, rid):
+                rid_list.append(int(rid))
+                rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
+                shutil.move(item_path, rid_dir_path)
     rid_list.sort()
     return rid_list
 

--- a/main.py
+++ b/main.py
@@ -388,7 +388,9 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         visualize_dataset[0] = visualize
     # move the modified experiment file to the RID directory
     if visualize:
-        src_experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
+        src_experiment_path = posixpath.join(
+            result_dir_path, f"experiment_{submission_time_str}.py"
+        )
         dst_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
         shutil.move(src_experiment_path, dst_experiment_path)
     # remove the metadata file

--- a/main.py
+++ b/main.py
@@ -373,6 +373,15 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
 
 @app.get("/result/")
 async def list_result_directory() -> List[int]:
+    """Post-processes the submitted experiments and returns the RID list.
+
+    It performs the following:
+        1. Organize the result directory.
+        2. Return the RID list.
+
+    Returns:
+        A list with RIDs of the submitted experiments, sorted in an ascending order.
+    """
     rid_list = []
     # read the most recently fetched RID
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])

--- a/main.py
+++ b/main.py
@@ -345,7 +345,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         with open(metadata_path, encoding="utf-8") as metadata_file:
             metadata = json.load(metadata_file)
     except OSError:  # no chance of happening
-        logger.exception(f"The RID {rid} directory has no metadata file.")
+        logger.exception("The RID %s directory has no metadata file.", rid)
         return False
     submission_time_str, visualize = metadata["submission_time"], metadata["visualize"]
     submission_time = datetime.fromisoformat(submission_time_str)

--- a/main.py
+++ b/main.py
@@ -375,12 +375,14 @@ async def list_result_directory() -> List[str]:
     # navigate to each RID directory
     for item in os.listdir(result_dir_path):
         item_path = posixpath.join(result_dir_path, item)
-        # find a RID directory
-        if posixpath.isdir(item_path) and item.isdigit() and int(item) > last_rid:
-            organize_result_directory(result_dir_path, item)
-            rid_list.append(int(item))
+        if posixpath.isdir(item_path) and item.isdigit():  # find a RID directory
+            rid = int(item)
+            if rid > last_rid:
+                organize_result_directory(result_dir_path, item)
+            rid_list.append(rid)
     # update the most recently fetched RID
-    last_rid = max(rid_list)
+    rid_list.sort()
+    last_rid = rid_list[-1] if rid_list else -1
     with open(last_rid_path, "w", encoding="utf-8") as last_rid_file:
         json.dump(last_rid, last_rid_file)
     return rid_list

--- a/main.py
+++ b/main.py
@@ -315,6 +315,18 @@ async def get_running_experiment() -> Optional[int]:
 
 
 def organize_result_directory(result_dir_path: str, rid: str):
+    """Organizes the result directory.
+    
+    It performs the following:
+        1. Read the metadata file from the RID directory and remove it.
+        2. Move the modified experiment to the RID directory.
+        3. Find the h5 result file and copy it to the RID directory.
+        4. Dump the metadata on the copied result file.
+
+    Args:
+        result_dir_path: The full path of the result directory.
+        rid: The RID string.
+    """
     rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
     # read and remove the metadata
     metadata_path = posixpath.join(rid_dir_path, "metadata.json")

--- a/main.py
+++ b/main.py
@@ -380,14 +380,14 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
 
 @app.get("/result/")
 async def list_result_directory() -> List[int]:
-    """Post-processes the submitted experiments and returns the RID list.
+    """Post-processes the executed experiments and returns the RID list.
 
     It performs the following:
         1. Organize the result directory.
         2. Return the RID list.
 
     Returns:
-        A list with RIDs of the submitted experiments, sorted in an ascending order.
+        A list with RIDs of the executed experiments, sorted in an ascending order.
     """
     rid_list = []
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])

--- a/main.py
+++ b/main.py
@@ -313,6 +313,10 @@ async def get_running_experiment() -> Optional[int]:
     return None
 
 
+def organize_result_directory():
+    pass
+
+
 @app.get("/result/")
 async def list_result_directory() -> List[str]:
     # read the most recently fetched RID
@@ -323,6 +327,11 @@ async def list_result_directory() -> List[str]:
             last_rid = json.load(last_rid_file)
     except FileNotFoundError:
         last_rid = -1
+    # navigate to each RID directory
+    for item in os.listdir(result_dir_path):
+        item_path = posixpath.join(result_dir_path, item)
+        if posixpath.isdir(item_path) and item.isdigit() and int(item) > last_rid:
+            pass
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -315,7 +315,13 @@ async def get_running_experiment() -> Optional[int]:
 
 @app.get("/result/")
 async def list_result_directory() -> List[str]:
-    pass
+    result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
+    last_rid_path = posixpath.join(result_dir_path, "rid.json")
+    try:
+        with open(last_rid_path, encoding="utf-8") as last_rid_file:
+            last_rid = json.load(last_rid_file)
+    except FileNotFoundError:
+        last_rid = -1
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ import pydantic
 from fastapi import FastAPI
 from sipyco import pc_rpc as rpc
 
+logger = logging.getLogger(__name__)
+
 configs = {}
 
 
@@ -343,6 +345,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         with open(metadata_path, encoding="utf-8") as metadata_file:
             metadata = json.load(metadata_file)
     except OSError:  # no chance of happening
+        logger.exception(f"The RID {rid} directory has no metadata file.")
         return False
     submission_time_str, visualize = metadata["submission_time"], metadata["visualize"]
     submission_time = datetime.fromisoformat(submission_time_str)

--- a/main.py
+++ b/main.py
@@ -254,13 +254,13 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
     submission_time = datetime.now().isoformat(timespec="seconds")
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
     if visualize:
-        experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
+        src_experiment_path = posixpath.join(configs["master_path"], configs["repository_path"], file)
         modified_experiment_path = posixpath.join(
             result_dir_path,
             f"experiment_{submission_time}.py"
         )
         # modify the experiment code
-        with open(experiment_path, encoding="utf-8") as experiment_file:
+        with open(src_experiment_path, encoding="utf-8") as experiment_file:
             code = experiment_file.read()
         modified_code = modify_experiment_code(code, cls)
         # save the modified experiment code
@@ -292,8 +292,8 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
         json.dump(metadata, metadata_file)
     if visualize:
         # copy the original experiment file
-        copied_experiment_path = posixpath.join(rid_dir_path, "experiment.py")
-        shutil.copyfile(experiment_path, copied_experiment_path)
+        dst_experiment_path = posixpath.join(rid_dir_path, "experiment.py")
+        shutil.copyfile(src_experiment_path, dst_experiment_path)
     return rid
 
 
@@ -365,9 +365,9 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         visualize_dataset[0] = visualize
     # move the modified experiment file to the RID directory
     if visualize:
-        experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
-        moved_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
-        shutil.move(experiment_path, moved_experiment_path)
+        src_experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
+        dst_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
+        shutil.move(src_experiment_path, dst_experiment_path)
     # remove the metadata file
     os.remove(metadata_path)
     return True

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 """Proxy server to communicate a client to ARTIQ."""
 
 import ast
-import h5py
 import json
 import logging
 import os
@@ -14,6 +13,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import h5py
 import pydantic
 from fastapi import FastAPI
 from sipyco import pc_rpc as rpc
@@ -315,6 +315,7 @@ async def get_running_experiment() -> Optional[int]:
     return None
 
 
+# pylint: disable=too-many-locals
 def organize_result_directory(result_dir_path: str, rid: str) -> bool:
     """Organizes the result directory.
     

--- a/main.py
+++ b/main.py
@@ -322,7 +322,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
     """Organizes the result directory.
     
     It performs the following:
-        1. Read the metadata file from the RID directory and remove it.
+        1. Read the metadata file from the RID directory.
         2. Move the modified experiment to the RID directory.
         3. Find the h5 result file and copy it to the RID directory.
         4. Dump the metadata on the copied result file.

--- a/main.py
+++ b/main.py
@@ -321,7 +321,8 @@ def organize_result_directory(result_dir_path: str, rid: str):
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = json.load(metadata_file)
     # find the result file
-    submission_time = datetime.fromisoformat(metadata["submission_time"])
+    submission_time_str = metadata["submission_time"]
+    submission_time = datetime.fromisoformat(submission_time_str)
     date = submission_time.date().isoformat()
     hour = submission_time.hour
     datetime_result_dir_path = posixpath.join(result_dir_path, f"{date}/{hour}/")
@@ -335,6 +336,12 @@ def organize_result_directory(result_dir_path: str, rid: str):
     item_path = posixpath.join(datetime_result_dir_path, item)
     result_path = posixpath.join(rid_dir_path, "result.h5")
     shutil.copyfile(item_path, result_path)
+    # modify the result file
+    with h5py.File(result_path, "a") as result_file:
+        submission_time_dataset = result_file.create_dataset(
+            "submission_time", (1,), dtype=h5py.string_dtype(encoding="utf-8")
+        )
+        submission_time_dataset[0] = submission_time_str
 
 
 @app.get("/result/")

--- a/main.py
+++ b/main.py
@@ -339,9 +339,10 @@ def organize_result_directory(result_dir_path: str, rid: str):
     date = submission_time.date().isoformat()
     hour = submission_time.hour
     # move the modified experiment file to the RID directory
-    experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
-    moved_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
-    shutil.move(experiment_path, moved_experiment_path)
+    if visualize:
+        experiment_path = posixpath.join(result_dir_path, f"experiment_{submission_time_str}.py")
+        moved_experiment_path = posixpath.join(rid_dir_path, "modified_experiment.py")
+        shutil.move(experiment_path, moved_experiment_path)
     # find the result file
     datetime_result_dir_path = posixpath.join(result_dir_path, f"{date}/{hour}/")
     padded_rid = rid.zfill(9)
@@ -365,7 +366,7 @@ def organize_result_directory(result_dir_path: str, rid: str):
 
 
 @app.get("/result/")
-async def list_result_directory() -> List[str]:
+async def list_result_directory() -> List[int]:
     rid_list = []
     # read the most recently fetched RID
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])

--- a/main.py
+++ b/main.py
@@ -401,7 +401,7 @@ async def list_result_directory() -> List[int]:
         item_path = posixpath.join(result_dir_path, item)
         if posixpath.isdir(item_path) and item.isdigit():  # find a RID directory
             rid = int(item)
-            if rid <= last_rid:  # alraedy organized
+            if rid <= last_rid:  # already organized
                 rid_list.append(rid)
                 continue
             if organize_result_directory(result_dir_path, item):

--- a/main.py
+++ b/main.py
@@ -352,11 +352,11 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
     else:  # no result file
         return False
     # copy the result file to the RID directory
-    result_path = posixpath.join(datetime_result_dir_path, item)
-    copied_result_path = posixpath.join(rid_dir_path, "result.h5")
-    shutil.copyfile(result_path, copied_result_path)
+    src_result_path = posixpath.join(datetime_result_dir_path, item)
+    dst_result_path = posixpath.join(rid_dir_path, "result.h5")
+    shutil.copyfile(src_result_path, dst_result_path)
     # modify the result file
-    with h5py.File(copied_result_path, "a") as result_file:
+    with h5py.File(dst_result_path, "a") as result_file:
         submission_time_dataset = result_file.create_dataset(
             "submission_time", (1,), dtype=h5py.string_dtype(encoding="utf-8")
         )

--- a/main.py
+++ b/main.py
@@ -284,7 +284,8 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
     os.makedirs(rid_dir_path)
     # save the metadata
     metadata = {
-        "submission_time": submission_time
+        "submission_time": submission_time,
+        "visualize": visualize
     }
     metadata_path = posixpath.join(rid_dir_path, "metadata.json")
     with open(metadata_path, "w", encoding="utf-8") as metadata_file:
@@ -333,7 +334,7 @@ def organize_result_directory(result_dir_path: str, rid: str):
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = json.load(metadata_file)
     os.remove(metadata_path)
-    submission_time_str = metadata["submission_time"]
+    submission_time_str, visualize = metadata["submission_time"], metadata["visualize"]
     submission_time = datetime.fromisoformat(submission_time_str)
     date = submission_time.date().isoformat()
     hour = submission_time.hour
@@ -359,6 +360,8 @@ def organize_result_directory(result_dir_path: str, rid: str):
             "submission_time", (1,), dtype=h5py.string_dtype(encoding="utf-8")
         )
         submission_time_dataset[0] = submission_time_str
+        visualize_dataset = result_file.create_dataset("visualize", (1,), dtype="bool")
+        visualize_dataset[0] = visualize
 
 
 @app.get("/result/")

--- a/main.py
+++ b/main.py
@@ -315,6 +315,7 @@ async def get_running_experiment() -> Optional[int]:
 
 @app.get("/result/")
 async def list_result_directory() -> List[str]:
+    # read the most recently fetched RID
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
     last_rid_path = posixpath.join(result_dir_path, "rid.json")
     try:

--- a/main.py
+++ b/main.py
@@ -363,6 +363,7 @@ def organize_result_directory(result_dir_path: str, rid: str):
 
 @app.get("/result/")
 async def list_result_directory() -> List[str]:
+    rid_list = []
     # read the most recently fetched RID
     result_dir_path = posixpath.join(configs["master_path"], configs["result_path"])
     last_rid_path = posixpath.join(result_dir_path, "rid.json")
@@ -374,9 +375,11 @@ async def list_result_directory() -> List[str]:
     # navigate to each RID directory
     for item in os.listdir(result_dir_path):
         item_path = posixpath.join(result_dir_path, item)
+        # find a RID directory
         if posixpath.isdir(item_path) and item.isdigit() and int(item) > last_rid:
             organize_result_directory(result_dir_path, item)
-    return []
+            rid_list.append(int(item))
+    return rid_list
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -379,6 +379,10 @@ async def list_result_directory() -> List[str]:
         if posixpath.isdir(item_path) and item.isdigit() and int(item) > last_rid:
             organize_result_directory(result_dir_path, item)
             rid_list.append(int(item))
+    # update the most recently fetched RID
+    last_rid = max(rid_list)
+    with open(last_rid_path, "w", encoding="utf-8") as last_rid_file:
+        json.dump(last_rid, last_rid_file)
     return rid_list
 
 

--- a/main.py
+++ b/main.py
@@ -335,7 +335,7 @@ def organize_result_directory(result_dir_path: str, rid: str) -> bool:
         Otherwise, stop organizing the result directory and return False. 
     """
     rid_dir_path = posixpath.join(result_dir_path, f"{rid}/")
-    # read and remove the metadata
+    # read the metadata
     metadata_path = posixpath.join(rid_dir_path, "metadata.json")
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = json.load(metadata_file)

--- a/main.py
+++ b/main.py
@@ -313,7 +313,7 @@ async def get_running_experiment() -> Optional[int]:
     return None
 
 
-def organize_result_directory():
+def organize_result_directory(rid: str):
     pass
 
 
@@ -331,7 +331,7 @@ async def list_result_directory() -> List[str]:
     for item in os.listdir(result_dir_path):
         item_path = posixpath.join(result_dir_path, item)
         if posixpath.isdir(item_path) and item.isdigit() and int(item) > last_rid:
-            pass
+            organize_result_directory(item)
 
 
 def get_client(target_name: str) -> rpc.Client:


### PR DESCRIPTION
This PR will close #38.

# What I implemented
- Organize each RID directory
  - When the experiment is submitted, it makes a RID directory, `_{RID}/`
  - After organizing, rename the RID directory to `{RID}/` (remove the leading underscore)
- Send the RID list

# How to fetch the result directory structure
```shell
curl -X GET 127.0.0.1:8000/result/
```

# Result
<img width="70%" src="https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/d4f0639e-f3af-434b-ad61-1e1886d74671">
