### PR TITLE
Send H5 format result file, code, and vcd file of the specific RID

### DIFF
--- a/main.py
+++ b/main.py
@@ -434,7 +434,15 @@ async def list_result_directory() -> List[int]:
 
 @app.get("/result/{rid}/h5/")
 async def get_h5_result_file(rid: str) -> FileResponse:
-    return FileResponse("blah.file")
+    """Gets the H5 format result file of the given RID and returns it.
+    
+    Args:
+        rid: The run identifier value in string.
+    """
+    h5_result_path = posixpath.join(
+        configs["master_path"], configs["result_path"], rid, "result.h5"
+    )
+    return FileResponse(h5_result_path)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import copy
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import h5py
@@ -432,17 +433,30 @@ async def list_result_directory() -> List[int]:
     return rid_list
 
 
-@app.get("/result/{rid}/h5/")
-async def get_h5_result_file(rid: str) -> FileResponse:
+class ResultFileType(str, Enum):
+    h5 = "h5"
+    code = "code"
+    vcd = "vcd"
+
+
+@app.get("/result/{rid}/{result_file_type}/")
+async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse:
     """Gets the H5 format result file of the given RID and returns it.
     
     Args:
         rid: The run identifier value in string.
+        result_file_type: The type of the requested result file in ResultFileType.
     """
-    h5_result_path = posixpath.join(
-        configs["master_path"], configs["result_path"], rid, "result.h5"
+    if result_file_type is ResultFileType.h5:
+        result_path = "result.h5"
+    elif result_file_type is ResultFileType.code:
+        result_path = "experiment.py"
+    else:
+        result_path = "rtio.vcd"
+    full_result_path = posixpath.join(
+        configs["master_path"], configs["result_path"], rid, result_path
     )
-    return FileResponse(h5_result_path)
+    return FileResponse(full_result_path)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 import h5py
 import pydantic
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
 from sipyco import pc_rpc as rpc
 
 logger = logging.getLogger(__name__)
@@ -429,6 +430,11 @@ async def list_result_directory() -> List[int]:
             rid_list.append(int(item))
     rid_list.sort()
     return rid_list
+
+
+@app.get("/result/{rid}/h5/")
+async def get_h5_result_file(rid: str) -> FileResponse:
+    return FileResponse("blah.file")
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -447,7 +447,7 @@ class ResultFileType(str, Enum):
 
 @app.get("/result/{rid}/{result_file_type}/")
 async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse:
-    """Gets the H5 format result file of the given RID and returns it.
+    """Gets the result file of the given RID for the given result file type and returns it.
     
     Args:
         rid: The run identifier value in string.

--- a/main.py
+++ b/main.py
@@ -434,9 +434,15 @@ async def list_result_directory() -> List[int]:
 
 
 class ResultFileType(str, Enum):
-    h5 = "h5"
-    code = "code"
-    vcd = "vcd"
+    """Enum class for describing the result file type.
+    
+    H5: The H5 format result file, result.h5.
+    CODE: The original experiment file, experiment.py.
+    VCD: The VCD format file, rtio.vcd.
+    """
+    H5 = "h5"
+    CODE = "code"
+    VCD = "vcd"
 
 
 @app.get("/result/{rid}/{result_file_type}/")
@@ -447,9 +453,9 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
         rid: The run identifier value in string.
         result_file_type: The type of the requested result file in ResultFileType.
     """
-    if result_file_type is ResultFileType.h5:
+    if result_file_type is ResultFileType.H5:
         result_path = "result.h5"
-    elif result_file_type is ResultFileType.code:
+    elif result_file_type is ResultFileType.CODE:
         result_path = "experiment.py"
     else:
         result_path = "rtio.vcd"


### PR DESCRIPTION
This closes #39 and closes #57.

Implementing to send these three files is similar, so I implemented these in one function, i.e. `get_result()`.

If there is no valid file, it would return 404 error so I didn't handle it explictily.