### PR TITLE
Skip the unittest about submission temporarily

### DIFF
--- a/test.py
+++ b/test.py
@@ -98,6 +98,7 @@ class RoutingTest(unittest.TestCase):
             client.post("/experiment/terminate/", params={"rid": test_rid})
             self.mocked_client.request_termination.assert_called_with(test_rid)
 
+    @unittest.skip("temporary skipping as discussed in #63")
     @mock.patch.dict("main.configs", {"repository_path": "repo_path/"})
     def test_submit_experiment(self):
         test_rid = 0


### PR DESCRIPTION
This closes #63.

I just added `@unittest.skip()` decorator to skip `test_submit_experiment()`.