### PR TITLE
Set the override and level option of a specific TTL

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,6 +24,7 @@ jobs:
         pip install h5py
         pip install fastapi
         pip install git+https://github.com/m-labs/sipyco.git
+        pip install git+https://github.com/m-labs/artiq.git
     - name: Analyze the code with pylint
       run: |
         pylint main.py --report=y

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,6 +26,7 @@ jobs:
         pip install httpx
         pip install numpy
         pip install git+https://github.com/m-labs/sipyco.git
+        pip install git+https://github.com/m-labs/artiq.git
     - name: Run the unit tests and check coverage
       run: |
         xvfb-run `which coverage` run -m unittest test.py

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
     "result_path": "results/",
+    "core_addr": "192.168.1.75",
     "ttl_dict": {
         "test_ttl0": 22,
         "test_ttl1": 23

--- a/config.json
+++ b/config.json
@@ -1,5 +1,9 @@
 {
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
-    "result_path": "results/"
+    "result_path": "results/",
+    "ttl_dict": {
+        "test_ttl0": 22,
+        "test_ttl1": 23
+    }
 }

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
     "result_path": "results/",
-    "core_addr": "192.168.1.75"
+    "core_addr": "192.168.1.75",
+    "ttl_channels": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
 }

--- a/config.json
+++ b/config.json
@@ -2,9 +2,5 @@
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
     "result_path": "results/",
-    "core_addr": "192.168.1.75",
-    "ttl_dict": {
-        "test_ttl0": 22,
-        "test_ttl1": 23
-    }
+    "core_addr": "192.168.1.75"
 }

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ async def lifespan(_app: FastAPI):
     load_config_file()
     await connect_moninj()
     yield
+    await mi_connection.close()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/main.py
+++ b/main.py
@@ -470,6 +470,11 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
     return FileResponse(full_result_path)
 
 
+@app.post("/ttl/level/")
+async def set_ttl_level(name: str, value: bool):
+    pass
+
+
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.
 

--- a/main.py
+++ b/main.py
@@ -485,19 +485,18 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
 
 
 @app.post("/ttl/level/")
-async def set_ttl_level(name: str, value: bool):
-    """Sets the overriding value of the given TTL.
+async def set_ttl_level(channel: int, value: bool):
+    """Sets the overriding value of the given TTL channel.
     
     This only sets a value to be output when overridden, but does not turn on overriding.
 
     Args:
-        name: The TTL name described in config.json.
+        channel: The TTL channel number described in device_db.py.
         value: The value to be output when overridden.
     """
-    if name not in configs["ttl_dict"]:
-        logger.exception("The TTL name %s is not defined in config.json." % name)
+    if channel not in configs["ttl_channels"]:
+        logger.exception("The TTL channel %d is not defined in config.json." % channel)
         return
-    channel = configs["ttl_dict"][name]
     mi_connection.inject(channel, TTLOverride.level.value, value)
 
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 configs = {}
 
-mi_connection = None  # pylint: disable=invalid-name
+mi_connection: Optional[CommMonInj] = None
 
 
 def load_config_file():

--- a/main.py
+++ b/main.py
@@ -498,7 +498,12 @@ async def set_ttl_level(channel: int, value: bool):
 
 @app.post("/ttl/override/")
 async def set_ttl_override(value: bool):
-    for channel in configs["ttl_dict"].values():
+    """Turns on or off overriding of all TTL channels.
+
+    Args:
+        value: Whether to turn on overriding or not. 
+    """
+    for channel in configs["ttl_channels"]:
         mi_connection.inject(channel, TTLOverride.en.value, value)
 
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 configs = {}
 
-mi_connection = None
+mi_connection = None  # pylint: disable=invalid-name
 
 
 def load_config_file():
@@ -48,7 +48,7 @@ async def connect_moninj():
     """Creates a CommMonInj instance and connects it to ARTIQ."""
     def do_nothing(*_):
         """Gets any input, but doesn't do anything."""
-    global mi_connection
+    global mi_connection  # pylint: disable=global-statement, invalid-name
     mi_connection = CommMonInj(do_nothing, do_nothing)
     await mi_connection.connect(configs["core_addr"])
 
@@ -491,7 +491,7 @@ async def set_ttl_level(channel: int, value: bool):
         value: The value to be output when overridden.
     """
     if channel not in configs["ttl_channels"]:
-        logger.exception("The TTL channel %d is not defined in config.json." % channel)
+        logger.exception("The TTL channel %d is not defined in config.json.", channel)
         return
     mi_connection.inject(channel, TTLOverride.level.value, value)
 

--- a/main.py
+++ b/main.py
@@ -49,9 +49,9 @@ def load_config_file():
 
 
 async def connect_moninj():
+    """Creates a CommMonInj instance and connects it to ARTIQ."""
     def do_nothing(*_):
         """Gets any input, but doesn't do anything."""
-
     global mi_connection
     mi_connection = CommMonInj(do_nothing, do_nothing)
     await mi_connection.connect(configs["core_addr"])

--- a/main.py
+++ b/main.py
@@ -486,6 +486,14 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
 
 @app.post("/ttl/level/")
 async def set_ttl_level(name: str, value: bool):
+    """Sets the overriding value of the given TTL.
+    
+    This only sets a value to be output when overridden, but does not turn on overriding.
+
+    Args:
+        name: The TTL name described in config.json.
+        value: The value to be output when overridden.
+    """
     if name not in configs["ttl_dict"]:
         logger.exception("The TTL name %s is not defined in config.json." % name)
         return

--- a/main.py
+++ b/main.py
@@ -501,6 +501,12 @@ async def set_ttl_level(name: str, value: bool):
     mi_connection.inject(channel, TTLOverride.level.value, value)
 
 
+@app.post("ttl/override/")
+async def set_ttl_override(value: bool):
+    for channel in configs["ttl_dict"].values():
+        
+
+
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.
 

--- a/main.py
+++ b/main.py
@@ -504,7 +504,7 @@ async def set_ttl_level(name: str, value: bool):
 @app.post("ttl/override/")
 async def set_ttl_override(value: bool):
     for channel in configs["ttl_dict"].values():
-        
+        mi_connection.inject(channel, TTLOverride.en.value, value)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -501,7 +501,7 @@ async def set_ttl_level(name: str, value: bool):
     mi_connection.inject(channel, TTLOverride.level.value, value)
 
 
-@app.post("ttl/override/")
+@app.post("/ttl/override/")
 async def set_ttl_override(value: bool):
     for channel in configs["ttl_dict"].values():
         mi_connection.inject(channel, TTLOverride.en.value, value)

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 import h5py
 import pydantic
-from artiq.coredevice.comm_moninj import CommMonInj
+from artiq.coredevice.comm_moninj import CommMonInj, TTLOverride
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from sipyco import pc_rpc as rpc
@@ -486,6 +486,9 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
 
 @app.post("/ttl/level/")
 async def set_ttl_level(name: str, value: bool):
+    if name not in configs["ttl_dict"]:
+        logger.exception("The TTL name %s is not defined in config.json." % name)
+        return
     print(mi_connection)
 
 

--- a/main.py
+++ b/main.py
@@ -31,9 +31,14 @@ def load_config_file():
     The file should have the following JSON structure:
 
       {
-        "master_path": {master_path}
-        "repository_path": {repository_path}
-        "result_path": {result_path}
+        "master_path": {master_path},
+        "repository_path": {repository_path},
+        "result_path": {result_path},
+        "ttl_dict": {
+            {nickname0}: {channel0},
+            {nickname1}: {channel1},
+            ...
+        }
       }
     """
     with open("config.json", encoding="utf-8") as config_file:

--- a/main.py
+++ b/main.py
@@ -489,7 +489,8 @@ async def set_ttl_level(name: str, value: bool):
     if name not in configs["ttl_dict"]:
         logger.exception("The TTL name %s is not defined in config.json." % name)
         return
-    print(mi_connection)
+    channel = configs["ttl_dict"][name]
+    mi_connection.inject(channel, TTLOverride.level.value, value)
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -37,11 +37,7 @@ def load_config_file():
         "master_path": {master_path},
         "repository_path": {repository_path},
         "result_path": {result_path},
-        "ttl_dict": {
-            {nickname0}: {channel0},
-            {nickname1}: {channel1},
-            ...
-        }
+        "ttl_channels": [{channel0}, {channel1}, ... ]
       }
     """
     with open("config.json", encoding="utf-8") as config_file:

--- a/test.py
+++ b/test.py
@@ -18,11 +18,18 @@ class RoutingTest(unittest.TestCase):
 
     def setUp(self):
         patcher_load_config_file = mock.patch("main.load_config_file")
+        patcher_connect_moninj = mock.patch("main.connect_moninj")
+        patcher_mi_connection = mock.patch("main.mi_connection")
         patcher_get_client = mock.patch("main.get_client")
-        self.mocked_load_config_file = patcher_load_config_file.start()
-        self.mocked_get_client = patcher_get_client.start()
-        self.mocked_client = self.mocked_get_client.return_value
+        patcher_load_config_file.start()
+        patcher_connect_moninj.start()
+        mocked_mi_connection = patcher_mi_connection.start()
+        mocked_mi_connection.close = mock.AsyncMock()
+        mocked_get_client = patcher_get_client.start()
+        self.mocked_client = mocked_get_client.return_value
         self.addCleanup(patcher_load_config_file.stop)
+        self.addCleanup(patcher_connect_moninj.stop)
+        self.addCleanup(patcher_mi_connection.stop)
         self.addCleanup(patcher_get_client.stop)
 
     @mock.patch.dict("main.configs",
@@ -31,7 +38,6 @@ class RoutingTest(unittest.TestCase):
         test_list = ["dir1/", "dir2/", "file1.py", "file2.py"]
         self.mocked_client.list_directory.return_value = test_list
         with TestClient(main.app) as client:
-            self.mocked_load_config_file.assert_called_once()
             for params in ({}, {"directory": "dir1/"}):
                 directory = params.get('directory', '')
                 response = client.get("/ls/", params=params)
@@ -52,7 +58,6 @@ class RoutingTest(unittest.TestCase):
         }
         self.mocked_client.examine.return_value = test_info
         with TestClient(main.app) as client:
-            self.mocked_load_config_file.assert_called_once()
             response = client.get("/experiment/info/", params={'file': 'experiment.py'})
             self.mocked_client.examine.assert_called_with("experiment.py")
             self.assertEqual(response.status_code, 200)
@@ -104,6 +109,7 @@ class RoutingTest(unittest.TestCase):
         self.mocked_client.submit.return_value = test_rid
         with TestClient(main.app) as client:
             self.mocked_load_config_file.assert_called_once()
+            self.mocked_connect_moninj.assert_called_once()
             test_params = (
                 {"file": "experiment1.py"},
                 {"file": "experiment2.py", "args": '{"k": "v"}'},

--- a/test.py
+++ b/test.py
@@ -108,8 +108,6 @@ class RoutingTest(unittest.TestCase):
         test_rid = 0
         self.mocked_client.submit.return_value = test_rid
         with TestClient(main.app) as client:
-            self.mocked_load_config_file.assert_called_once()
-            self.mocked_connect_moninj.assert_called_once()
             test_params = (
                 {"file": "experiment1.py"},
                 {"file": "experiment2.py", "args": '{"k": "v"}'},


### PR DESCRIPTION
This closes #66.

For details, please read #66.

To test in miniPC, you can use the following commands.
```shell
$ curl -X POST 'http://127.0.0.1:8000/ttl/level/?channel=23&value=True'  // set the level of channel 23 to HIGH
$ curl -X POST 'http://127.0.0.1:8000/ttl/override/?value=True'  // set the override of all channels to TRUE
```