### PR TITLE
Set the voltage of a specific DAC

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
     "repository_path": "repository/",
     "result_path": "results/",
     "core_addr": "192.168.1.75",
-    "ttl_channels": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    "ttl_channels": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+    "dac_devices": ["zotino0"]
 }

--- a/main.py
+++ b/main.py
@@ -524,14 +524,13 @@ from artiq.experiment import *
 class {class_name}(EnvExperiment):
     def build(self):
         self.setattr_device("core")
-        self.setattr_device("ttl23")
+        self.dac = self.get_device({device})
 
     @kernel
     def run(self):
         self.core.reset()
-        self.ttl23.on()
-        delay(2*s)
-        self.ttl23.off()
+        self.dac.init()
+        self.dac.set_dac([{value}], [{channel}])
 """
     expid = {
         "log_level": logging.WARNING,

--- a/main.py
+++ b/main.py
@@ -530,6 +530,7 @@ class {class_name}(EnvExperiment):
     def run(self):
         self.core.reset()
         self.dac.init()
+        delay(200*us)
         self.dac.set_dac([{value}], [{channel}])
 """
     expid = {

--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ def load_config_file():
         "master_path": {master_path},
         "repository_path": {repository_path},
         "result_path": {result_path},
-        "ttl_channels": [{channel0}, {channel1}, ... ]
+        "ttl_channels": [{channel0}, {channel1}, ... ],
+        "dac_devices": [{dac_device0}, {dac_device1}, ... ]
       }
     """
     with open("config.json", encoding="utf-8") as config_file:

--- a/main.py
+++ b/main.py
@@ -508,6 +508,17 @@ async def set_ttl_override(value: bool):
         mi_connection.inject(channel, TTLOverride.en.value, value)
 
 
+@app.post("/dac/voltage/")
+async def set_dac_voltage(device: str, channel: int, value: float):
+    """Sets the voltage of the given DAC channel.
+    
+    Args:
+        device: The DAC device name described in device_db.py.
+        channel: The DAC channel number. For Zotino, there are 32 channels, from 0 to 31.
+        value: The voltage to set. For Zotino, the valid range is from -10V to +10V.
+    """
+
+
 def get_client(target_name: str) -> rpc.Client:
     """Creates a client connecting to ARTIQ and returns it.
 

--- a/main.py
+++ b/main.py
@@ -517,6 +517,31 @@ async def set_dac_voltage(device: str, channel: int, value: float):
         channel: The DAC channel number. For Zotino, there are 32 channels, from 0 to 31.
         value: The voltage to set. For Zotino, the valid range is from -10V to +10V.
     """
+    class_name = "SetDACVoltage"
+    content = f"""
+from artiq.experiment import *
+
+class {class_name}(EnvExperiment):
+    def build(self):
+        self.setattr_device("core")
+        self.setattr_device("ttl23")
+
+    @kernel
+    def run(self):
+        self.core.reset()
+        self.ttl23.on()
+        delay(2*s)
+        self.ttl23.off()
+"""
+    expid = {
+        "log_level": logging.WARNING,
+        "content": content,
+        "class_name": class_name,
+        "arguments": {},
+    }
+    remote = get_client("master_schedule")
+    rid = remote.submit("main", expid, 0, None, False)
+    return rid
 
 
 def get_client(target_name: str) -> rpc.Client:


### PR DESCRIPTION
This closes #69.

I didn't check through an oscilloscope, but checked that the submission works well and there is no error in artiq-master.

### How to send a query
```shell
# set the voltage of channel 1 in DAC zotino0 to 5V
curl -X POST 'http://127.0.0.1:8000/dac/voltage/?device="zotino0"&channel=1&value=5'
```