### PR TITLE
Use TTL name to set the override and level

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,10 @@
     "repository_path": "repository/",
     "result_path": "results/",
     "core_addr": "192.168.1.75",
-    "ttl_channels": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+    "ttl_devices": [
+        "ttl4", "ttl5", "ttl6", "ttl7", "ttl8", "ttl9", "ttl10", "ttl11", "ttl12", "ttl13",
+        "ttl14", "ttl15", "ttl16", "ttl17", "ttl18", "ttl19", "ttl20", "ttl21", "ttl22", "ttl23",
+        "led0", "led1"
+    ],
     "dac_devices": ["zotino0"]
 }

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
     "master_path": "/home/rabi/artiq/",
     "repository_path": "repository/",
     "result_path": "results/",
+    "device_db_path": "device_db.py",
     "core_addr": "192.168.1.75",
     "ttl_devices": [
         "ttl4", "ttl5", "ttl6", "ttl7", "ttl8", "ttl9", "ttl10", "ttl11", "ttl12", "ttl13",

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def load_config_file():
         "master_path": {master_path},
         "repository_path": {repository_path},
         "result_path": {result_path},
-        "ttl_channels": [{channel0}, {channel1}, ... ],
+        "ttl_devices": [{ttl_device0}, {ttl_device1}, ... ],
         "dac_devices": [{dac_device0}, {dac_device1}, ... ]
       }
     """

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Proxy server to communicate a client to ARTIQ."""
 
 import ast
+import importlib.util
 import json
 import logging
 import os
@@ -51,6 +52,12 @@ def load_configs():
 
 def load_device_db():
     """Loads device DB from the device DB file."""
+    device_db_full_path = posixpath.join(configs["master_path"], configs["device_db_path"])
+    module_name = "device_db"
+    spec = importlib.util.spec_from_file_location(module_name, device_db_full_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    device_db.update(module.device_db)
 
 
 async def connect_moninj():

--- a/main.py
+++ b/main.py
@@ -535,7 +535,8 @@ async def set_ttl_override(value: bool):
     Args:
         value: Whether to turn on overriding or not. 
     """
-    for channel in configs["ttl_channels"]:
+    for device in configs["ttl_devices"]:
+        channel = device_db[device]["arguments"]["channel"]
         mi_connection.inject(channel, TTLOverride.en.value, value)
 
 

--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 configs = {}
 
+device_db = {}
+
 mi_connection: Optional[CommMonInj] = None
 
 
@@ -38,12 +40,17 @@ def load_config_file():
         "master_path": {master_path},
         "repository_path": {repository_path},
         "result_path": {result_path},
+        "device_db_path": {device_db_path},
         "ttl_devices": [{ttl_device0}, {ttl_device1}, ... ],
         "dac_devices": [{dac_device0}, {dac_device1}, ... ]
       }
     """
     with open("config.json", encoding="utf-8") as config_file:
         configs.update(json.load(config_file))
+
+
+def load_device_db():
+    """Loads device DB from the device DB file."""
 
 
 async def connect_moninj():
@@ -62,6 +69,7 @@ async def lifespan(_app: FastAPI):
     This function is set as the lifespan of the application.
     """
     load_config_file()
+    load_device_db()
     await connect_moninj()
     yield
     await mi_connection.close()

--- a/main.py
+++ b/main.py
@@ -512,18 +512,19 @@ async def get_result(rid: str, result_file_type: ResultFileType) -> FileResponse
 
 
 @app.post("/ttl/level/")
-async def set_ttl_level(channel: int, value: bool):
+async def set_ttl_level(device: str, value: bool):
     """Sets the overriding value of the given TTL channel.
     
     This only sets a value to be output when overridden, but does not turn on overriding.
 
     Args:
-        channel: The TTL channel number described in device_db.py.
+        device: The TTL device name described in device_db.py.
         value: The value to be output when overridden.
     """
-    if channel not in configs["ttl_channels"]:
-        logger.exception("The TTL channel %d is not defined in config.json.", channel)
+    if device not in configs["ttl_devices"]:
+        logger.exception("The TTL device %s is not defined in config.json.", device)
         return
+    channel = device_db[device]["arguments"]["channel"]
     mi_connection.inject(channel, TTLOverride.level.value, value)
 
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ device_db = {}
 mi_connection: Optional[CommMonInj] = None
 
 
-def load_config_file():
+def load_config():
     """Loads config information from the configuration file.
 
     The file should have the following JSON structure:
@@ -68,7 +68,7 @@ async def lifespan(_app: FastAPI):
 
     This function is set as the lifespan of the application.
     """
-    load_config_file()
+    load_config()
     load_device_db()
     await connect_moninj()
     yield

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ device_db = {}
 mi_connection: Optional[CommMonInj] = None
 
 
-def load_config():
+def load_configs():
     """Loads config information from the configuration file.
 
     The file should have the following JSON structure:
@@ -68,7 +68,7 @@ async def lifespan(_app: FastAPI):
 
     This function is set as the lifespan of the application.
     """
-    load_config()
+    load_configs()
     load_device_db()
     await connect_moninj()
     yield

--- a/test.py
+++ b/test.py
@@ -149,7 +149,7 @@ class FunctionTest(unittest.TestCase):
     @mock.patch("json.load",
                 return_value={"master_path": "master_path/", "repository_path": "repo_path/"})
     def test_load_config_file(self, mocked_load, mocked_open):
-        main.load_config_file()
+        main.load_config()
         mocked_open.assert_called_once_with("config.json", encoding="utf-8")
         mocked_load.assert_called_once()
         self.assertEqual(

--- a/test.py
+++ b/test.py
@@ -149,7 +149,7 @@ class FunctionTest(unittest.TestCase):
     @mock.patch("json.load",
                 return_value={"master_path": "master_path/", "repository_path": "repo_path/"})
     def test_load_config_file(self, mocked_load, mocked_open):
-        main.load_config()
+        main.load_configs()
         mocked_open.assert_called_once_with("config.json", encoding="utf-8")
         mocked_load.assert_called_once()
         self.assertEqual(

--- a/test.py
+++ b/test.py
@@ -17,17 +17,20 @@ class RoutingTest(unittest.TestCase):
     """Unit tests for routing and each operation."""
 
     def setUp(self):
-        patcher_load_config_file = mock.patch("main.load_config_file")
+        patcher_load_configs = mock.patch("main.load_configs")
+        patcher_load_device_db = mock.patch("main.load_device_db")
         patcher_connect_moninj = mock.patch("main.connect_moninj")
         patcher_mi_connection = mock.patch("main.mi_connection")
         patcher_get_client = mock.patch("main.get_client")
-        patcher_load_config_file.start()
+        patcher_load_configs.start()
+        patcher_load_device_db.start()
         patcher_connect_moninj.start()
         mocked_mi_connection = patcher_mi_connection.start()
         mocked_mi_connection.close = mock.AsyncMock()
         mocked_get_client = patcher_get_client.start()
         self.mocked_client = mocked_get_client.return_value
-        self.addCleanup(patcher_load_config_file.stop)
+        self.addCleanup(patcher_load_configs.stop)
+        self.addCleanup(patcher_load_device_db.stop)
         self.addCleanup(patcher_connect_moninj.stop)
         self.addCleanup(patcher_mi_connection.stop)
         self.addCleanup(patcher_get_client.stop)
@@ -148,7 +151,7 @@ class FunctionTest(unittest.TestCase):
     @mock.patch("builtins.open")
     @mock.patch("json.load",
                 return_value={"master_path": "master_path/", "repository_path": "repo_path/"})
-    def test_load_config_file(self, mocked_load, mocked_open):
+    def test_load_configs(self, mocked_load, mocked_open):
         main.load_configs()
         mocked_open.assert_called_once_with("config.json", encoding="utf-8")
         mocked_load.assert_called_once()


### PR DESCRIPTION
This closes #75.

To send a query, use the following commands:
```shell
# Set the level
$ curl -X POST 'http://127.0.0.1:8000/ttl/level/?device=ttl23&value=True'

# Set the override
$ curl -X POST 'http://127.0.0.1:8000/ttl/override/?value=True'
```

I tested if setting the level and override worked well.