### PR TITLE
Track last deletion timestamps

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -75,6 +75,7 @@ class DatasetTracker:
         """
         self._maxlen = maxlen
         self._modifications: Dict[str, ModificationQueue] = {}
+        self._last_deleted: Dict[str, float] = {}
 
     def datasets(self) -> Tuple[str, ...]:
         """Returns the available dataset names."""
@@ -84,9 +85,12 @@ class DatasetTracker:
         """Adds a dataset entry.
         
         Args:
-            dataset: New dataset name.
+            dataset: New dataset name. If the same name already exists, it is
+              overwritten by the new one. Since the old one is deleted, the time
+              is saved in _last_deleted.
         """
         if dataset in self._modifications:
+            self._last_deleted[dataset] = time.time()
             logger.warning("Dataset %s already exists hence is replaced.", dataset)
         self._modifications[dataset] = ModificationQueue(self._maxlen)
 
@@ -99,6 +103,8 @@ class DatasetTracker:
         removed = self._modifications.pop(dataset, None)
         if removed is None:
             logger.error("Cannot remove dataset %s since it does not exist.", dataset)
+            return
+        self._last_deleted[dataset] = time.time()
 
     def add(self, dataset: str, timestamp: float, modification: Modification):
         """Adds a modification record.
@@ -123,9 +129,16 @@ class DatasetTracker:
               Any modifications added after this timestamp will be returned.
         
         Returns:
-            If dataset does not exist, it returns (-1, ()).
-            Otherwise, see SortedQueue.tail().
+            (t, m) where t is the latest timestamp of the modifications and m is
+              a tuple of modifications that are made strictly after the given
+              timestamp.
+            When the dataset was deleted after the given timestamp (even if it
+              exists now) or it does not exist, it returns (-1, ()).
+            Note that when there is no modification after the given timestamp,
+              it returns (timestamp, ()).
         """
+        if self._last_deleted.get(dataset, -1) > timestamp:
+            return (-1, ())
         queue = self._modifications.get(dataset, None)
         if queue is None:
             logger.error("Cannot call since() for dataset %s since it does not exist.", dataset)


### PR DESCRIPTION
By recording the last deletion timestamps, it can notify the client that the dataset has been deleted or reset.

See also: #87