### PR TITLE
Long polling for `get_dataset_modification()`

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -66,13 +66,19 @@ ModificationQueue = SortedQueue[float, Modification]
 
 
 class DatasetTracker:
-    """Holds dataset modifications and provides searching API."""
+    """Holds dataset modifications and provides searching API.
+    
+    Attributes:
+        modified: Dict(key=dataset_name, value=event) where the event is set
+          when any new modification to the dataset is added.
+    """
 
     def __init__(self, maxlen: Optional[int] = None):
         """
         Args:
             maxlen: The maximum length of modification queues.
         """
+        self.modified: Dict[str, asyncio.Event] = {}
         self._maxlen = maxlen
         self._modifications: Dict[str, ModificationQueue] = {}
         self._last_deleted: Dict[str, float] = {}

--- a/dataset.py
+++ b/dataset.py
@@ -1,5 +1,6 @@
 """Module for realtime dataset management."""
 
+import asyncio
 import bisect
 import itertools
 import logging
@@ -98,7 +99,9 @@ class DatasetTracker:
         if dataset in self._modifications:
             self._last_deleted[dataset] = time.time()
             logger.warning("Dataset %s already exists hence is replaced.", dataset)
+            self._notify_modified(dataset)
         self._modifications[dataset] = ModificationQueue(self._maxlen)
+        self.modified[dataset] = asyncio.Event()
 
     def remove_dataset(self, dataset: str):
         """Removes a dataset entry.

--- a/dataset.py
+++ b/dataset.py
@@ -130,6 +130,7 @@ class DatasetTracker:
             logger.error("Cannot add modification to dataset %s since it does not exist.", dataset)
             return
         queue.push(timestamp, modification)
+        self._notify_modified(dataset)
 
     def since(self, dataset: str, timestamp: float) -> Tuple[float, Tuple[Modification, ...]]:
         """Returns the latest timestamp and modifications since the given timestamp.

--- a/dataset.py
+++ b/dataset.py
@@ -114,6 +114,8 @@ class DatasetTracker:
             logger.error("Cannot remove dataset %s since it does not exist.", dataset)
             return
         self._last_deleted[dataset] = time.time()
+        self._notify_modified(dataset)
+        self.modified.pop(dataset)
 
     def add(self, dataset: str, timestamp: float, modification: Modification):
         """Adds a modification record.

--- a/dataset.py
+++ b/dataset.py
@@ -145,6 +145,18 @@ class DatasetTracker:
             return (-1, ())
         return queue.tail(timestamp)
 
+    def _notify_modified(self, dataset: str):
+        """Sets and clears the modified event.
+
+        All the coroutines that are waiting for the modified event will be awakened.
+        
+        Args:
+            dataset: Target dataset name.
+        """
+        modified = self.modified[dataset]
+        modified.set()
+        modified.clear()
+
 
 def notify_callback(tracker: DatasetTracker, mod: Dict[str, Any]):
     """Adds modification to the tracker called as notify_cb() of sipyco system.

--- a/main.py
+++ b/main.py
@@ -587,8 +587,7 @@ async def get_dataset_modification(
     if modifications or latest < 0 or timeout <= 0:
         return latest, modifications
     try:
-        async with asyncio.timeout(timeout):
-            await dataset_tracker.modified[key].wait()
+        await asyncio.wait_for(dataset_tracker.modified[key].wait(), timeout)
     except asyncio.TimeoutError:
         return latest, modifications
     return dataset_tracker.since(key, timestamp)

--- a/main.py
+++ b/main.py
@@ -584,7 +584,7 @@ async def get_dataset_modification(
           it can guarantee a valid return value for even short timeouts.
     """
     latest, modifications = dataset_tracker.since(key, timestamp)
-    if modifications or latest < 0 or timeout <= 0:
+    if modifications or latest < 0 or (timeout is not None and timeout <= 0):
         return latest, modifications
     try:
         await asyncio.wait_for(dataset_tracker.modified[key].wait(), timeout)

--- a/main.py
+++ b/main.py
@@ -580,7 +580,7 @@ async def get_dataset_modification(
         timeout: The timeout in seconds for awaiting new modifications.
           None for no timeout (wait until done), and 0 or negative for non-blocking.
           The actual execution time might exceed the timeout because of the
-          first since() call. Although the timeout becomes less precise,
+          since() calls are not timed. Although the timeout becomes less precise,
           it can guarantee a valid return value for even short timeouts.
     """
     latest, modifications = dataset_tracker.since(key, timestamp)


### PR DESCRIPTION
This PR establishes a long polling system for `get_dataset_modification()`.

I tested some scenarios and it works well.
1. Immediately return `(-1, ())` when the dataset does not exist
2. Immediately return `(-1, ())` when the dataset has been deleted after the given timestamp
3. Immediately return valid values when there is modifications since the given timestamp
4. Wait for given timeout and return `(timestamp, ())` when the dataset exists and there was no modification since the given timestamp for given timeout
5. In case 4, if some modifications are added before the timeout, it returns valid values
6. In case 4, if the dataset is deleted or reset, it returns `(-1, ())`

See also: #87