### PR TITLE
Support hardware control during experiments 

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "core_addr": "192.168.1.75",
     "master_addr": "localhost",
     "notify_port": 3250,
+    "experiment_port": 10000,
     "ttl_devices": [
         "ttl4", "ttl5", "ttl6", "ttl7", "ttl8", "ttl9", "ttl10", "ttl11", "ttl12", "ttl13",
         "ttl14", "ttl15", "ttl16", "ttl17", "ttl18", "ttl19", "ttl20", "ttl21", "ttl22", "ttl23",

--- a/main.py
+++ b/main.py
@@ -823,6 +823,7 @@ class {class_name}(EnvExperiment):
     return rid
 
 
+# pylint: disable=too-many-return-statements
 def send_command_to_experiment(command: dict[str, Any]) -> bool:
     """Sends the given command to the running experiment."""
     try:

--- a/main.py
+++ b/main.py
@@ -830,6 +830,12 @@ def send_command_to_experiment(command: dict[str, Any]) -> bool:
     except OSError:
         logger.exception("Failed to create a socket.")
         return False
+    try:
+        s.connect((configs["master_addr"], configs["experiment_port"]))
+    except OSError:
+        s.close()
+        logger.exception("Failed to connect to the running experiment.")
+        return False
 
 
 @app.post("/control/")

--- a/main.py
+++ b/main.py
@@ -872,7 +872,7 @@ async def control_hardware_during_experiment(request: Request) -> bool:
     command = {}
     hardware = params.get("hardware", "")
     device = params.get("device", "")
-    channel = params.get("channel", -1)
+    channel = int(params.get("channel", -1))
     if hardware == "DAC":
         if device not in configs["dac_devices"] or channel not in configs["dac_devices"][device]:
             logger.error("The DAC device %s CH %d is not defined in config.json.", device, channel)
@@ -883,7 +883,7 @@ async def control_hardware_during_experiment(request: Request) -> bool:
         command.update({
             "device": device,
             "func": "set_dac",
-            "args": [[params["voltage"]], [channel]]
+            "args": [[float(params["voltage"])], [channel]]
         })
     elif hardware == "DDS":
         if device not in configs["dds_devices"] or channel not in configs["dds_devices"][device]:
@@ -895,16 +895,16 @@ async def control_hardware_during_experiment(request: Request) -> bool:
         if "profile" in params:
             command.update({
                 "func": "set",
-                "kwargs": params["profile"]
+                "kwargs": eval(params["profile"])
             })
         elif "attenuation" in params:
             command.update({
                 "func": "set_att",
-                "args": [params["attenuation"]]
+                "args": [float(params["attenuation"])]
             })
         elif "switch" in params:
             command.update({
-                "func": "sw.on" if params["switch"] else "sw.off"
+                "func": "sw.on" if bool(params["switch"]) else "sw.off"
             })
         else:
             logger.error("One of profile, attenuation, and switch should be set.")

--- a/main.py
+++ b/main.py
@@ -880,10 +880,11 @@ async def control_hardware_during_experiment(request: Request) -> bool:
         if "voltage" not in params:
             logger.error("The voltage should be set.")
             return
+        voltage = float(params["voltage"])
         command.update({
             "device": device,
             "func": "voltage",
-            "args": {"channel": channel, "voltage": params["voltage"]}
+            "args": {"channel": channel, "voltage": voltage}
         })
     elif hardware == "DDS":
         if device not in configs["dds_devices"] or channel not in configs["dds_devices"][device]:

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ def load_configs():
         "core_addr": {core_ip},
         "master_addr": {artiq_master_ip},
         "nofity_port": {nofity_port},
+        "experiment_port": {experiment_port},
         "ttl_devices": [{ttl_device0}, {ttl_device1}, ... ],
         "dac_devices": {
             {dac_device0}: [{dac_device0_channel0}, {dac_device0_channel1}, ... ],

--- a/main.py
+++ b/main.py
@@ -843,7 +843,28 @@ async def control_hardware_during_experiment(request: Request):
             "args": [[voltage], [channel]]
         })
     elif hardware == "DDS":
-        pass
+        if device not in configs["dds_devices"] or channel not in configs["dds_devices"][device]:
+            logger.error("The DDS device %s CH %d is not defined in config.json.", device, channel)
+            return
+        command.update({
+            "device": f"{device}_ch{channel}"
+        })
+        if "profile" in params:
+            command.update({
+                "func": "set",
+                "kwargs": params["profile"]
+            })
+        elif "attenuation" in params:
+            command.update({
+                "func": "set_att",
+                "args": [params["attenuation"]]
+            })
+        elif "switch" in params:
+            command.update({
+                "func": "sw.on" if params["switch"] else "sw.off"
+            })
+        else:
+            logger.error("One of profile, attenuation, and switch should be set.")
     else:
         logger.error("The hardware %s is not supported in control during an experiment.", hardware)
 

--- a/main.py
+++ b/main.py
@@ -865,6 +865,7 @@ async def control_hardware_during_experiment(request: Request):
             })
         else:
             logger.error("One of profile, attenuation, and switch should be set.")
+            return
     else:
         logger.error("The hardware %s is not supported in control during an experiment.", hardware)
 

--- a/main.py
+++ b/main.py
@@ -833,6 +833,15 @@ async def control_hardware_during_experiment(request: Request):
         if device not in configs["dac_devices"] or channel not in configs["dac_devices"][device]:
             logger.error("The DAC device %s CH %d is not defined in config.json.", device, channel)
             return
+        voltage = params.get("voltage", None)
+        if voltage is None:
+            logger.error("The voltage should be set.")
+            return
+        command.update({
+            "device": device,
+            "func": "set_dac",
+            "args": [[voltage], [channel]]
+        })
     elif hardware == "DDS":
         pass
     else:

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import logging
 import os
 import posixpath
 import shutil
+import socket
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -823,6 +824,11 @@ class {class_name}(EnvExperiment):
 
 def send_command_to_experiment(command: dict[str, Any]) -> bool:
     """Sends the given command to the running experiment."""
+    try:
+        s = socket.socket()
+    except OSError:
+        logger.exception("Failed to create a socket.")
+        return False
 
 
 @app.post("/control/")

--- a/main.py
+++ b/main.py
@@ -826,6 +826,11 @@ class {class_name}(EnvExperiment):
 def send_command_to_experiment(command: dict[str, Any]) -> bool:
     """Sends the given command to the running experiment."""
     try:
+        command_str = json.dumps(command)
+    except TypeError:
+        logger.exception("Failed to serialize the command.")
+        return False
+    try:
         s = socket.socket()
     except OSError:
         logger.exception("Failed to create a socket.")
@@ -835,6 +840,12 @@ def send_command_to_experiment(command: dict[str, Any]) -> bool:
     except OSError:
         s.close()
         logger.exception("Failed to connect to the running experiment.")
+        return False
+    try:
+        s.send(command_str.encode())
+    except OSError:
+        s.close()
+        logger.exception("Failed to send the command.")
         return False
 
 

--- a/main.py
+++ b/main.py
@@ -847,6 +847,12 @@ def send_command_to_experiment(command: dict[str, Any]) -> bool:
         s.close()
         logger.exception("Failed to send the command.")
         return False
+    try:
+        response = s.recv(1024)
+    except OSError:
+        s.close()
+        logger.exception("Failed to receive a response.")
+        return False
 
 
 @app.post("/control/")

--- a/main.py
+++ b/main.py
@@ -826,9 +826,13 @@ async def control_hardware_during_experiment(request: Request):
     """Controls an ARTIQ hardware while an experiment is running."""
     params = request.query_params
     command = {}
-    hardware = params.get("hardware", None)
+    hardware = params.get("hardware", "")
+    device = params.get("device", "")
+    channel = params.get("channel", -1)
     if hardware == "DAC":
-        pass
+        if device not in configs["dac_devices"] or channel not in configs["dac_devices"][device]:
+            logger.error("The DAC device %s CH %d is not defined in config.json.", device, channel)
+            return
     elif hardware == "DDS":
         pass
     else:

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ import h5py
 import numpy as np
 import pydantic
 from artiq.coredevice.comm_moninj import CommMonInj, TTLOverride
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse
 from sipyco import pc_rpc as rpc
 from sipyco.sync_struct import Subscriber
@@ -819,6 +819,11 @@ class {class_name}(EnvExperiment):
     remote = get_client("master_schedule")
     rid = remote.submit("main", expid, 0, None, False)
     return rid
+
+
+@app.post("/control/")
+async def control_hardware_during_experiment(request: Request):
+    """Controls an ARTIQ hardware while an experiment is running."""
 
 
 def get_client(target_name: str) -> rpc.Client:

--- a/main.py
+++ b/main.py
@@ -848,11 +848,21 @@ def send_command_to_experiment(command: dict[str, Any]) -> bool:
         logger.exception("Failed to send the command.")
         return False
     try:
-        response = s.recv(1024)
+        response_str = s.recv(1024).decode()
     except OSError:
         s.close()
         logger.exception("Failed to receive a response.")
         return False
+    s.close()
+    try:
+        response = json.loads(response_str)
+    except TypeError:
+        logger.exception("Failed to deserialize the response.")
+        return False
+    if not isinstance(response, bool):
+        logger.exception("The type of response should be boolean.")
+        return False
+    return response
 
 
 @app.post("/control/")

--- a/main.py
+++ b/main.py
@@ -882,8 +882,8 @@ async def control_hardware_during_experiment(request: Request) -> bool:
             return
         command.update({
             "device": device,
-            "func": "set_dac",
-            "args": [[float(params["voltage"])], [channel]]
+            "func": "voltage",
+            "args": {"channel": channel, "voltage": params["voltage"]}
         })
     elif hardware == "DDS":
         if device not in configs["dds_devices"] or channel not in configs["dds_devices"][device]:

--- a/main.py
+++ b/main.py
@@ -824,6 +824,15 @@ class {class_name}(EnvExperiment):
 @app.post("/control/")
 async def control_hardware_during_experiment(request: Request):
     """Controls an ARTIQ hardware while an experiment is running."""
+    params = request.query_params
+    command = {}
+    hardware = params.get("hardware", None)
+    if hardware == "DAC":
+        pass
+    elif hardware == "DDS":
+        pass
+    else:
+        logger.error("The hardware %s is not supported in control during an experiment.", hardware)
 
 
 def get_client(target_name: str) -> rpc.Client:


### PR DESCRIPTION
This is the first step of #103. For details, please read the issue.

I'm sorry for late PR, because making an experiment that meet this function required much more debugging than I thought..

### NOT covered in this PR
- Safe termination of the experiment.
- Notification for if the currently running experiment supports the real-time hardware control.

An example experiment that supports the real-time hardware control is as follows.
It is not completed, but only supports to set a DAC voltage.
```python
import json
import socket
from artiq.experiment import *

ZOTINO0 = 0
URUKUL0_CH0 = 1
URUKUL0_CH1 = 2
URUKUL0_CH2 = 3
URUKUL0_CH3 = 4

VOLTAGE = 0
PROFILE = 1
ATTENUATION = 2
SWITCH = 3

class ControlHardwareExample(EnvExperiment):
    """Control Hardware Example"""

    def build(self):
        self.setattr_device("core")
        self.ttl = self.get_device("ttl23")
        self.zotino0 = self.get_device("zotino0")

    @kernel
    def run(self):
        self.core.reset()
        # create a server socket
        self.init_socket()
        self.core.break_realtime()
        # run with two flows; experiment and socket communication
        with parallel:
            self.run_experiment()
            with sequential:
                while True:
                    command = self.receive()
                    self.core.break_realtime()
                    self.control_hardware(command)
                    self.send_response()
                    self.close()
        # close the socket
        self.close_socket()

    @kernel
    def run_experiment(self):
        """Repeats a pulse with 1s duration 100 times."""
        for _ in range(100):
            self.ttl.pulse(0.5*s)
            delay(0.5*s)

    def init_socket(self):
        self.s = socket.socket()
        self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        self.s.bind(("", 10000))
        self.s.listen(10)

    def receive(self) -> TList(TFloat):
        self.conn, _ = self.s.accept()
        command_str = self.conn.recv(1024)
        command = json.loads(command_str)
        device = {
            "zotino0": ZOTINO0,
            "urukul0_ch0": URUKUL0_CH0,
            "urukul0_ch1": URUKUL0_CH1
        }[command["device"]]  # not completed
        func = {
            "voltage": VOLTAGE,
            "profile": PROFILE,
            "attenuation": ATTENUATION
        }[command["func"]]
        args = command["args"]
        if device == ZOTINO0 and func == VOLTAGE:
            return [device, func, args["channel"], args["value"]]
        return [device, func]  # not completed

    @kernel
    def control_hardware(self, command):
        self.core.break_realtime()
        # in here, handle only if the device is zotino0 and the func is set_dac
        device = command[0]
        func = command[1]
        if device == ZOTINO0:
            self.zotino0.init()
            delay(200*us)
            if func == VOLTAGE:
                channel = int(command[2])
                voltage = command[3]
                self.zotino0.set_dac([voltage], [channel])

    def send_response(self):
        self.conn.send(json.dumps(True).encode())

    def close(self):
        self.conn.close()

    def close_socket(self):
        self.s.close()
```

For test, you can follow the step below in mini PC.
1. Run the above experiment.
```shell
$ artiq_client submit repository/test_jaehun/socket/example.py
```
2. Request the hardware control to the proxy server. Now, the example experiment only supports to set a DAC voltage.
```shell
$ curl -X POST 'http://127.0.0.1:8000/control/' -d '{"hardware": "DAC", "device": "zotino0", "channel": 7, "voltage": 4}'
```