### PR TITLE
Send schedule using web socket

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,8 +23,10 @@ jobs:
       run: |
         pip install h5py
         pip install fastapi
+        pip install websockets
         pip install git+https://github.com/m-labs/sipyco.git
         pip install git+https://github.com/m-labs/artiq.git
     - name: Analyze the code with pylint
       run: |
-        pylint main.py --report=y
+        pylint --ignore=test.py *.py --report=y
+        pylint test.py --rcfile .pylintrc_test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         pip install h5py
         pip install fastapi
+        pip install websockets
         pip install httpx
         pip install numpy
         pip install git+https://github.com/m-labs/sipyco.git

--- a/.pylintrc_test
+++ b/.pylintrc_test
@@ -1,0 +1,2 @@
+[MASTER]
+extension-pkg-whitelist=pydantic

--- a/.pylintrc_test
+++ b/.pylintrc_test
@@ -1,2 +1,6 @@
 [MASTER]
 extension-pkg-whitelist=pydantic
+
+[MESSAGES CONTROL]
+disable=
+    missing-docstring,

--- a/main.py
+++ b/main.py
@@ -221,7 +221,7 @@ async def get_schedule(websocket: WebSocket):
         schedule = schedule_tracker.get()
         await websocket.send_json(schedule)
         while True:
-            await asyncio.wait_for(schedule_tracker.modifed.wait(), None)
+            await schedule_tracker.modifed.wait()
             schedule = schedule_tracker.get()
             await websocket.send_json(schedule)
     except websockets.exceptions.ConnectionClosedError:

--- a/main.py
+++ b/main.py
@@ -17,8 +17,9 @@ from typing import Any, Optional, Union
 import h5py
 import numpy as np
 import pydantic
+import websockets
 from artiq.coredevice.comm_moninj import CommMonInj, TTLOverride
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket
 from fastapi.responses import FileResponse
 from sipyco import pc_rpc as rpc
 from sipyco.sync_struct import Subscriber
@@ -205,17 +206,12 @@ async def get_experiment_info(file: str) -> Any:
     return remote.examine(file)
 
 
-@app.get("/schedule/")
-async def get_schedule(timestamp: float, timeout: Optional[float]) -> tuple[float, schd.Schedule]:
-    """Returns the current schedule.
-    
-    Args:
-        timestamp: The timestamp of the last update.
-        timeout: The timeout in seconds for awaiting new modifications.
-          None for no timeout (wait until done), and 0 or negative for non-blocking.
+@app.websocket("/schedule/")
+async def get_schedule(websocket: WebSocket):
+    """Sends the schedule whenever it is modified.
 
-    Returns:
-        See ScheduleTracker.get().
+    Args:
+        websocket: The web socket object.
     """
     latest, schedule = schedule_tracker.get()
     if timestamp < latest or (timeout is not None and timeout <= 0):

--- a/main.py
+++ b/main.py
@@ -210,6 +210,9 @@ async def get_experiment_info(file: str) -> Any:
 async def get_schedule(websocket: WebSocket):
     """Sends the schedule whenever it is modified.
 
+    After accepted, it sends the current schedule immediately.
+    Then, it sends the schedule every time it is modified.
+
     Args:
         websocket: The web socket object.
     """

--- a/main.py
+++ b/main.py
@@ -219,7 +219,7 @@ async def get_schedule(websocket: WebSocket):
     await websocket.accept()
     try:
         schedule = schedule_tracker.get()
-        await websocket.send_json(schedule)  # send the current schedule on the first connection.
+        await websocket.send_json(schedule)
         while True:
             await asyncio.wait_for(schedule_tracker.modifed.wait(), None)
             schedule = schedule_tracker.get()

--- a/main.py
+++ b/main.py
@@ -218,7 +218,7 @@ async def get_schedule(websocket: WebSocket):
         schedule = schedule_tracker.get()
         await websocket.send_json(schedule)  # send the current schedule on the first connection.
         while True:
-            await asyncio.wait_for(schedule_tracker.modifed.wait())
+            await asyncio.wait_for(schedule_tracker.modifed.wait(), None)
             schedule = schedule_tracker.get()
             await websocket.send_json(schedule)
     except websockets.exceptions.ConnectionClosedError:

--- a/schedule.py
+++ b/schedule.py
@@ -14,25 +14,22 @@ class ScheduleTracker(Tracker[Schedule]):
     
     Attributes:
         modified: The event set when any new modification to the schedule is added.
-        latest: The timestamp of the last modification.
     """
 
     def __init__(self):
         """Extended."""
         super().__init__()
         self.modifed = asyncio.Event()
-        self.latest = -1
 
-    def get(self) -> tuple[float, Schedule]:
-        """Returns the latest timestamp and the current schedule."""
-        return self.latest, self._target
+    def get(self) -> Schedule:
+        """Returns the current schedule."""
+        return self._target
     
     def notify_modified(self):
         """Sets and clears the modified event.
         
         All the coroutines that are waiting for the modified event will be awakened.
         """
-        self.latest = time.time()
         self.modifed.set()
         self.modifed.clear()
 

--- a/schedule.py
+++ b/schedule.py
@@ -1,7 +1,6 @@
 """Module for realtime schedule management."""
 
 import asyncio
-import time
 from typing import Any
 
 from tracker import Tracker
@@ -24,7 +23,7 @@ class ScheduleTracker(Tracker[Schedule]):
     def get(self) -> Schedule:
         """Returns the current schedule."""
         return self._target
-    
+
     def notify_modified(self):
         """Sets and clears the modified event.
         


### PR DESCRIPTION
Now, a client i.e. IQUIP can fetch schedule using a web socket.

For test, run the code below.
```python
import json
from websockets.sync.client import connect

def main():
    uri = "ws://localhost:8000/schedule/"

    with connect(uri) as websocket:
        while True:
            response = websocket.recv()
            data = json.loads(response)
            print(data)

main()
```

Its result is the following.

![image](https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/fdb7748d-0eac-4c5a-8d2c-30698f56c955)

Additionally, I found out we didn't check Pylint for other files except for `main.py`, thus I updated it.

This closes #113.