### PR TITLE
Send dataset using websocket

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "master_path": "/home/rabi/artiq/",
+    "master_path": "/home/quiqcl/artiq/",
     "repository_path": "repository/",
     "result_path": "results/",
     "device_db_path": "device_db.py",

--- a/dataset.py
+++ b/dataset.py
@@ -73,6 +73,7 @@ class DatasetTracker(Tracker[Dataset]):
     """Holds dataset modifications and provides searching API.
     
     Attributes:
+        list_modified: The event set when the dataset list is modified.
         modified: Dict(key=dataset_name, value=event) where the event is set
           when any new modification to the dataset is added.
     """
@@ -83,6 +84,7 @@ class DatasetTracker(Tracker[Dataset]):
             maxlen: The maximum length of modification queues.
         """
         super().__init__()
+        self.list_modified = asyncio.Event()
         self.modified: dict[str, asyncio.Event] = {}
         self._maxlen = maxlen
         self._modifications: dict[str, ModificationQueue] = {}
@@ -106,6 +108,7 @@ class DatasetTracker(Tracker[Dataset]):
             self._notify_modified(dataset)
         self._modifications[dataset] = ModificationQueue(self._maxlen)
         self.modified[dataset] = asyncio.Event()
+        self._notify_list_modified()
 
     def remove_dataset(self, dataset: str):
         """Removes a dataset entry.
@@ -120,6 +123,8 @@ class DatasetTracker(Tracker[Dataset]):
         self._last_deleted[dataset] = time.time()
         self._notify_modified(dataset)
         self.modified.pop(dataset)
+        self._notify_list_modified()
+
 
     def add(self, dataset: str, timestamp: float, modification: Modification):
         """Adds a modification record.
@@ -178,8 +183,16 @@ class DatasetTracker(Tracker[Dataset]):
             return -1, ()
         return time.time(), value[1]  # value = persist, data, metadata
 
+    def _notify_list_modified(self):
+        """Sets and clears the modified event for the dataset list.
+        
+        All the coroutines that are waiting for the modified event will be awakened.
+        """
+        self.list_modified.set()
+        self.list_modified.clear()
+
     def _notify_modified(self, dataset: str):
-        """Sets and clears the modified event.
+        """Sets and clears the modified event for the specific dataset.
 
         All the coroutines that are waiting for the modified event will be awakened.
         

--- a/dataset.py
+++ b/dataset.py
@@ -64,11 +64,12 @@ class SortedQueue(Generic[K, V]):
         return latest_key, values
 
 
+Dataset = dict[str, Any]
 Modification = dict[str, Any]
 ModificationQueue = SortedQueue[float, Modification]
 
 
-class DatasetTracker(Tracker[dict[str, Any]]):
+class DatasetTracker(Tracker[Dataset]):
     """Holds dataset modifications and provides searching API.
     
     Attributes:

--- a/dataset.py
+++ b/dataset.py
@@ -102,13 +102,15 @@ class DatasetTracker(Tracker[Dataset]):
               overwritten by the new one. Since the old one is deleted, the time
               is saved in _last_deleted.
         """
-        if dataset in self._modifications:
+        overwritten = dataset in self._modifications
+        if overwritten:
             self._last_deleted[dataset] = time.time()
             logger.warning("Dataset %s already exists hence is replaced.", dataset)
             self._notify_modified(dataset)
         self._modifications[dataset] = ModificationQueue(self._maxlen)
         self.modified[dataset] = asyncio.Event()
-        self._notify_list_modified()
+        if not overwritten:
+            self._notify_list_modified()
 
     def remove_dataset(self, dataset: str):
         """Removes a dataset entry.

--- a/main.py
+++ b/main.py
@@ -562,7 +562,6 @@ async def list_dataset(websocket: WebSocket):
     await websocket.accept()
     try:
         datasets = dataset_tracker.datasets()
-        # send the current dataset list on the first connection.
         await websocket.send_json(datasets)
         while True:
             await asyncio.wait_for(dataset_tracker.list_modified.wait(), None)

--- a/main.py
+++ b/main.py
@@ -145,9 +145,9 @@ async def lifespan(_app: FastAPI):
     load_device_db()
     _schedule_task = await init_schedule_tracker()
     _dataset_task = await init_dataset_tracker()
-    await connect_moninj()
+    # await connect_moninj()
     yield
-    await mi_connection.close()
+    # await mi_connection.close()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -589,8 +589,8 @@ async def get_dataset_modification(websocket: WebSocket):
     await websocket.accept()
     try:
         name = await websocket.receive_json()
-        timestamp, data = dataset_tracker.get(name)
-        await websocket.send_json(data)
+        timestamp, dataset = dataset_tracker.get(name)
+        await websocket.send_json(dataset)
         _, parameters = dataset_tracker.get(f"{name}.parameters")
         await websocket.send_json(parameters)
         _, units = dataset_tracker.get(f"{name}.units")

--- a/main.py
+++ b/main.py
@@ -579,7 +579,7 @@ async def get_dataset_modification(websocket: WebSocket):
 
     After accepted, it receives the target dataset name.
     Then, it sends the current dataset, parameters, and units immediately.
-    Finally, it sends the dataset modificiation every time it is modified.
+    Finally, it sends the dataset modificiation at least a second apart, every time it is modified.
 
     For details about dataset modificiation, see dataset.DatasetTracker.since().
 
@@ -595,6 +595,15 @@ async def get_dataset_modification(websocket: WebSocket):
         await websocket.send_json(parameters)
         _, units = dataset_tracker.get(f"{name}.units")
         await websocket.send_json(units)
+        while True:
+            await asyncio.wait_for(dataset_tracker.modified[name].wait(), None)
+            latest, modifications = dataset_tracker.since(name, timestamp)
+            if latest < 0:  # dataset is overwritten or removed
+                await websocket.send_json(None)
+                break
+            if latest > timestamp + 1:  # changes within 1 second are buffered
+                timestamp = latest
+                await websocket.send_json(modifications)
     except websockets.exceptions.ConnectionClosedError:
         logger.info("The connection for sending the dataset modification is closed.")
     except websockets.exceptions.WebSocketException:

--- a/main.py
+++ b/main.py
@@ -553,6 +553,9 @@ async def get_master_dataset(key: str) -> Union[int, float, list]:
 async def list_dataset(websocket: WebSocket):
     """Sends the list of datasets available in artiq master whenever it is modified.
     
+    After accepted, it sends the current dataset list immediately.
+    Then, it sends the dataset list every time it is modified.
+
     Args:
         websocket: The web socket object.
     """

--- a/main.py
+++ b/main.py
@@ -587,14 +587,13 @@ async def get_dataset_modification(websocket: WebSocket):
     Args:
         websocket: The web socket object.
     """
-    latest, modifications = dataset_tracker.since(key, timestamp)
-    if modifications or latest < 0 or (timeout is not None and timeout <= 0):
-        return latest, modifications
+    await websocket.accept()
     try:
-        await asyncio.wait_for(dataset_tracker.modified[key].wait(), timeout)
-    except asyncio.TimeoutError:
-        return latest, modifications
-    return dataset_tracker.since(key, timestamp)
+        key = await websocket.receive_json()
+    except websockets.exceptions.ConnectionClosedError:
+        logger.info("The connection for sending the dataset modification is closed.")
+    except websockets.exceptions.WebSocketException:
+        logger.exception("Failed to send the dataset modification.")
 
 
 class ResultFileType(str, Enum):

--- a/main.py
+++ b/main.py
@@ -145,9 +145,9 @@ async def lifespan(_app: FastAPI):
     load_device_db()
     _schedule_task = await init_schedule_tracker()
     _dataset_task = await init_dataset_tracker()
-    # await connect_moninj()
+    await connect_moninj()
     yield
-    # await mi_connection.close()
+    await mi_connection.close()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/main.py
+++ b/main.py
@@ -562,7 +562,7 @@ async def list_dataset(websocket: WebSocket):
         # send the current dataset list on the first connection.
         await websocket.send_json(datasets)
         while True:
-            await asyncio.wait_for(dataset_tracker.list_modifed.wait(), None)
+            await asyncio.wait_for(dataset_tracker.list_modified.wait(), None)
             datasets = dataset_tracker.datasets()
             await websocket.send_json(datasets)
     except websockets.exceptions.ConnectionClosedError:

--- a/main.py
+++ b/main.py
@@ -590,6 +590,8 @@ async def get_dataset_modification(websocket: WebSocket):
     await websocket.accept()
     try:
         key = await websocket.receive_json()
+        _, data = dataset_tracker.get(key)
+        await websocket.send_json(data)
     except websockets.exceptions.ConnectionClosedError:
         logger.info("The connection for sending the dataset modification is closed.")
     except websockets.exceptions.WebSocketException:

--- a/main.py
+++ b/main.py
@@ -534,19 +534,19 @@ async def list_result_directory() -> list[int]:
 
 
 @app.get("/dataset/master/")
-async def get_master_dataset(key: str) -> tuple[float, Union[int, float, list]]:
-    """Returns the current timestamp and the dataset broadcast to artiq master.
+async def get_master_dataset(key: str) -> Union[int, float, list]:
+    """Returns the dataset broadcast to artiq master.
 
     Args:
         key: The key of the target dataset.
 
     Returns:
-        If the dataset is not initialized or does not exist, it returns (-1, ()).
+        If the dataset is not initialized or does not exist, it returns an empty tuple.
     """
-    timestamp, array = dataset_tracker.get(key)
-    if isinstance(array, np.ndarray):
-        array = array.tolist()
-    return timestamp, array
+    _, data = dataset_tracker.get(key)
+    if isinstance(data, np.ndarray):
+        data = data.tolist()
+    return data
 
 
 @app.get("/dataset/master/list/")

--- a/main.py
+++ b/main.py
@@ -574,22 +574,18 @@ async def list_dataset(websocket: WebSocket):
         logger.exception("Failed to send the dataset list.")
 
 
-@app.get("/dataset/master/modification/")
-async def get_dataset_modification(
-    key: str, timestamp: float, timeout: Optional[float],
-) -> tuple[float, tuple[dset.Modification, ...]]:
-    """Returns the dataset modifications since the given timestamp.
-    
-    See dataset.DatasetTracker.since() for details.
+@app.websocket("/dataset/master/modification/")
+async def get_dataset_modification(websocket: WebSocket):
+    """Sends the specific dataset modification whenever it is modified.
+
+    After accepted, it receives the target dataset name.
+    Then, it sends the current dataset, parameters, and units immediately.
+    Finally, it sends the dataset modificiation every time it is modified.
+
+    For details about dataset modificiation, see dataset.DatasetTracker.since().
 
     Args:
-        key: The key of the target dataset.
-        timestamp: The timestamp of the last update.
-        timeout: The timeout in seconds for awaiting new modifications.
-          None for no timeout (wait until done), and 0 or negative for non-blocking.
-          The actual execution time might exceed the timeout because of the
-          since() calls are not timed. Although the timeout becomes less precise,
-          it can guarantee a valid return value for even short timeouts.
+        websocket: The web socket object.
     """
     latest, modifications = dataset_tracker.since(key, timestamp)
     if modifications or latest < 0 or (timeout is not None and timeout <= 0):

--- a/main.py
+++ b/main.py
@@ -588,9 +588,13 @@ async def get_dataset_modification(websocket: WebSocket):
     """
     await websocket.accept()
     try:
-        key = await websocket.receive_json()
-        _, data = dataset_tracker.get(key)
+        name = await websocket.receive_json()
+        timestamp, data = dataset_tracker.get(name)
         await websocket.send_json(data)
+        _, parameters = dataset_tracker.get(f"{name}.parameters")
+        await websocket.send_json(parameters)
+        _, units = dataset_tracker.get(f"{name}.units")
+        await websocket.send_json(units)
     except websockets.exceptions.ConnectionClosedError:
         logger.info("The connection for sending the dataset modification is closed.")
     except websockets.exceptions.WebSocketException:


### PR DESCRIPTION
Now, the proxy server supports to send dataset in real-time through a web socket.

### `get_master_dataset()`: GET /dataset/master/
It will not be used, but I left it for a convenience, e.g., debugging.

### `list_dataset()`: Web socket /dataset/master/list/
It sends the available dataset in real-time.
An example experiment code is like below.
```python
import time
from artiq.experiment import *

class DatasetTest(EnvExperiment):
    """Dataset Test"""

    def build(self):
        self.setattr_device("core")

    @kernel
    def run(self):
        self.set_dataset("a", [], broadcast=True)
        for i in range(10):
            self.append_to_dataset("a", i+1)
            time.sleep(1)
        self.set_dataset("b", [], broadcast=True)
        time.sleep(2)
```

First, start the proxy sever and run the following web socket client code.
```python
import json
from websockets.sync.client import connect

def main():
    uri = "ws://localhost:8000/dataset/master/list/"

    with connect(uri) as websocket:
        for response in websocket:
            response = json.loads(response)
            print(response)
         
main()
```
Then, submit the experiment code.

The result of the client code is as follows.

![image](https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/fc7203f6-40bd-42aa-8701-f36aaac5e0d4)

### `get_dataset_modification()`: Web socket /dataset/master/modification/
Like sending the dataset list, it sends the modification of the specific dataset in real-time.
In addition, it sends at least a second apart to prevent high network demand.

First, start the proxy server and submit the above experiment.
```python
import json
from websockets.sync.client import connect

def main():
    uri = "ws://localhost:8000/dataset/master/modification/"

    with connect(uri) as websocket:
        key = json.dumps("a")
        websocket.send(key)
        for response in websocket:
            response = json.loads(response)
            if response is None:
                break
            print(response)
            
main()
```

Finally, run the client code above and the result is as follows.

![image](https://github.com/snu-quiqcl/artiq-proxy/assets/76851886/d59b4737-57a3-40ce-8d85-4cef7a071178)
The first three lines are the current dataset, parameters, and units, respectively.
And, the following lines are modifications of the dataset.

This closes #115.