### PR TITLE
Get current status of a specific experiment

### DIFF
--- a/main.py
+++ b/main.py
@@ -403,6 +403,23 @@ async def submit_experiment(  # pylint: disable=too-many-arguments, too-many-loc
     return rid
 
 
+@app.get("/experiment/status/")
+async def get_status(rid: int) -> Optional[dict]:
+    """Gets the current status of the given RID.
+    
+    Args:
+        rid: The run identifier value of the experiment.
+    
+    Returns:
+        A status dictionary with "pipeline", "expid", "priority", "due_date", "status", etc.
+        If the experiment is done or cancelled, it returns None.
+        For details, see notification in artiq.master.scheduler.Run.__init__().
+    """
+    remote = get_client("master_schedule")
+    status = remote.get_status()
+    return status.get(rid, None)
+
+
 @app.get("/experiment/running/")
 async def get_running_experiment() -> Optional[int]:
     """Gets the running experiment RID.


### PR DESCRIPTION
This closes #121.

For test, please use the command below.
```shell
$ curl -X GET 127.0.0.1:8000/experiment/status/?rid=702

{"pipeline":"main","expid":{"log_level":30,"class_name":"DatasetTest","arguments":{},"file":"/home/jaehun/quiqcl/artiq/examples/repository/dataset_test.py"},"priority":1,"due_date":null,"flush":false,"status":"running","repo_msg":null}
```